### PR TITLE
Fix spacing in README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <p>用三个独立入口完成经历酥化、简历制作和秋招进度管理。</p>
 </div>
 
-ASu-skills 现在是一个 插件包。安装后会提供三个可单独调用的入口：
+ASu-skills 现在是一个插件包。安装后会提供三个可单独调用的入口：
 
 [![Build with CODEX](https://img.shields.io/badge/Build%20with-CODEX-59B390?style=for-the-badge&logo=openai&logoColor=white)](https://chatgpt.com/codex) [![GitHub Stars](https://img.shields.io/github/stars/Hisn00w/ASu-skills?style=for-the-badge)](https://github.com/Hisn00w/ASu-skills/stargazers)
 


### PR DESCRIPTION
## 修改内容

删除 README 项目简介中“一个”和“插件包”之间多余的空格。

## 原因与影响

原文存在一处轻微的中文排版问题。此次修改仅改善阅读流畅度，不改变文档含义或项目行为。

## 验证

- 运行 `git diff --check`，检查通过
- 确认变更仅涉及 `README.md` 的一行文本

Closes #7