### PR TITLE
docs: fix Claude Code shared resource installation

### DIFF
--- a/Install-In-ClaudeCode.md
+++ b/Install-In-ClaudeCode.md
@@ -21,6 +21,19 @@ cd /path/to/your-project
 # 创建 skill 和 ASu 命名空间资源目录
 mkdir -p .claude/skills .claude/assets/asu .claude/references/asu
 
+# 重装前备份可编辑的求职进度表；不会覆盖已有备份
+tracker_path=.claude/assets/asu/application-tracker.html
+if [ -f "$tracker_path" ]; then
+  backup_path="${tracker_path}.bak"
+  backup_index=1
+  while [ -e "$backup_path" ]; do
+    backup_path="${tracker_path}.bak.${backup_index}"
+    backup_index=$((backup_index + 1))
+  done
+  cp "$tracker_path" "$backup_path"
+  printf '已备份现有求职进度表: %s\n' "$backup_path"
+fi
+
 # 复制四个 skill 和共享资源
 cp -r "$asu_skills_dir/skills/."     .claude/skills/
 cp -r "$asu_skills_dir/assets/."     .claude/assets/asu/
@@ -33,10 +46,23 @@ Windows PowerShell 版：
 $sourceRoot = "D:\DevProject\ASu-skills"
 $targetRoot = Join-Path (Get-Location) ".claude"
 New-Item -ItemType Directory -Path (Join-Path $targetRoot "skills"),(Join-Path $targetRoot "assets\asu"),(Join-Path $targetRoot "references\asu") -Force | Out-Null
+$trackerPath = Join-Path $targetRoot "assets\asu\application-tracker.html"
+if (Test-Path -LiteralPath $trackerPath -PathType Leaf) {
+    $backupPath = "$trackerPath.bak"
+    $backupIndex = 1
+    while (Test-Path -LiteralPath $backupPath) {
+        $backupPath = "$trackerPath.bak.$backupIndex"
+        $backupIndex++
+    }
+    Copy-Item -LiteralPath $trackerPath -Destination $backupPath -ErrorAction Stop
+    Write-Output "已备份现有求职进度表: $backupPath"
+}
 Copy-Item (Join-Path $sourceRoot "skills\*") (Join-Path $targetRoot "skills") -Recurse -Force
 Copy-Item (Join-Path $sourceRoot "assets\*") (Join-Path $targetRoot "assets\asu") -Recurse -Force
 Copy-Item (Join-Path $sourceRoot "references\*") (Join-Path $targetRoot "references\asu") -Recurse -Force
 ```
+
+重复安装会在替换 `application-tracker.html` 前创建不覆盖的 `.bak` 备份，以保留用户在进度表中的编辑；其余共享资源照常更新。
 
 **最终目录结构（`skills/` 下的每个 skill 必须含 `SKILL.md`）：**
 
@@ -137,6 +163,17 @@ Write-Output "ASu-skills 安装检查通过。"
 asu_skills_dir=/path/to/ASu-skills
 
 mkdir -p ~/.claude/skills ~/.claude/assets/asu ~/.claude/references/asu
+tracker_path="$HOME/.claude/assets/asu/application-tracker.html"
+if [ -f "$tracker_path" ]; then
+  backup_path="${tracker_path}.bak"
+  backup_index=1
+  while [ -e "$backup_path" ]; do
+    backup_path="${tracker_path}.bak.${backup_index}"
+    backup_index=$((backup_index + 1))
+  done
+  cp "$tracker_path" "$backup_path"
+  printf '已备份现有求职进度表: %s\n' "$backup_path"
+fi
 cp -r "$asu_skills_dir/skills/."     ~/.claude/skills/
 cp -r "$asu_skills_dir/assets/."     ~/.claude/assets/asu/
 cp -r "$asu_skills_dir/references/." ~/.claude/references/asu/
@@ -148,6 +185,17 @@ Windows PowerShell 用户级安装：
 $sourceRoot = "D:\DevProject\ASu-skills"
 $targetRoot = Join-Path $env:USERPROFILE ".claude"
 New-Item -ItemType Directory -Path (Join-Path $targetRoot "skills"),(Join-Path $targetRoot "assets\asu"),(Join-Path $targetRoot "references\asu") -Force | Out-Null
+$trackerPath = Join-Path $targetRoot "assets\asu\application-tracker.html"
+if (Test-Path -LiteralPath $trackerPath -PathType Leaf) {
+    $backupPath = "$trackerPath.bak"
+    $backupIndex = 1
+    while (Test-Path -LiteralPath $backupPath) {
+        $backupPath = "$trackerPath.bak.$backupIndex"
+        $backupIndex++
+    }
+    Copy-Item -LiteralPath $trackerPath -Destination $backupPath -ErrorAction Stop
+    Write-Output "已备份现有求职进度表: $backupPath"
+}
 Copy-Item (Join-Path $sourceRoot "skills\*") (Join-Path $targetRoot "skills") -Recurse -Force
 Copy-Item (Join-Path $sourceRoot "assets\*") (Join-Path $targetRoot "assets\asu") -Recurse -Force
 Copy-Item (Join-Path $sourceRoot "references\*") (Join-Path $targetRoot "references\asu") -Recurse -Force
@@ -296,4 +344,3 @@ if ($userExistingPaths.Count -gt 0) {
     }
 }
 ```
-

--- a/Install-In-ClaudeCode.md
+++ b/Install-In-ClaudeCode.md
@@ -30,7 +30,10 @@ if [ -f "$tracker_path" ]; then
     backup_path="${tracker_path}.bak.${backup_index}"
     backup_index=$((backup_index + 1))
   done
-  cp "$tracker_path" "$backup_path"
+  if ! cp "$tracker_path" "$backup_path"; then
+    printf '无法备份现有求职进度表，安装已停止: %s\n' "$tracker_path" >&2
+    exit 1
+  fi
   printf '已备份现有求职进度表: %s\n' "$backup_path"
 fi
 
@@ -171,7 +174,10 @@ if [ -f "$tracker_path" ]; then
     backup_path="${tracker_path}.bak.${backup_index}"
     backup_index=$((backup_index + 1))
   done
-  cp "$tracker_path" "$backup_path"
+  if ! cp "$tracker_path" "$backup_path"; then
+    printf '无法备份现有求职进度表，安装已停止: %s\n' "$tracker_path" >&2
+    exit 1
+  fi
   printf '已备份现有求职进度表: %s\n' "$backup_path"
 fi
 cp -r "$asu_skills_dir/skills/."     ~/.claude/skills/
@@ -233,7 +239,7 @@ Claude Code 根据 `description` 自动匹配技能，直接说人话即可：
 | 事项 | 说明 |
 | --- | --- |
 | `agents/openai.yaml` | Codex 专属配置，Claude Code 会忽略，保留或删除均可 |
-| `/contributor` 权限 | 本安装文档不授予远端写权限；具体授权以最新版 contributor skill 的逐项确认规则为准，未确认前只做只读扫描和本地 diff，使用最小 Git/GitHub 权限，不要使用 `--dangerously-skip-permissions` |
+| `/contributor` 权限 | 本文只说明安装，不授予或承诺 GitHub 写操作。使用 `/contributor` 前，请直接阅读已安装版本的 `skills/contributor/SKILL.md` 和目标仓库规则；在未阅读这些契约前，不执行 fork、push、PR、评论或 thread resolution，也不要使用 `--dangerously-skip-permissions` |
 | 项目级安装与 git | `.claude/skills` 默认会进 git，适合团队共享；若只想自己用，请改用方式 2 或加入 `.gitignore` |
 | 路径问题 | `resume` 和 `offer` 依赖 `.claude/assets/asu`、`.claude/references/asu`，必须复制共享资源，不要只拷 `SKILL.md` 或四个 skill 文件夹 |
 

--- a/Install-In-ClaudeCode.md
+++ b/Install-In-ClaudeCode.md
@@ -18,13 +18,13 @@ asu_skills_dir=/path/to/ASu-skills
 # 进入你的工作项目
 cd /path/to/your-project
 
-# 创建 skill 和共享资源目录
-mkdir -p .claude/skills .claude/assets .claude/references
+# 创建 skill 和 ASu 命名空间资源目录
+mkdir -p .claude/skills .claude/assets/asu .claude/references/asu
 
 # 复制四个 skill 和共享资源
 cp -r "$asu_skills_dir/skills/."     .claude/skills/
-cp -r "$asu_skills_dir/assets/."     .claude/assets/
-cp -r "$asu_skills_dir/references/." .claude/references/
+cp -r "$asu_skills_dir/assets/."     .claude/assets/asu/
+cp -r "$asu_skills_dir/references/." .claude/references/asu/
 ```
 
 Windows PowerShell 版：
@@ -32,10 +32,10 @@ Windows PowerShell 版：
 ```powershell
 $sourceRoot = "D:\DevProject\ASu-skills"
 $targetRoot = Join-Path (Get-Location) ".claude"
-New-Item -ItemType Directory -Path (Join-Path $targetRoot "skills"),(Join-Path $targetRoot "assets"),(Join-Path $targetRoot "references") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $targetRoot "skills"),(Join-Path $targetRoot "assets\asu"),(Join-Path $targetRoot "references\asu") -Force | Out-Null
 Copy-Item (Join-Path $sourceRoot "skills\*") (Join-Path $targetRoot "skills") -Recurse -Force
-Copy-Item (Join-Path $sourceRoot "assets\*") (Join-Path $targetRoot "assets") -Recurse -Force
-Copy-Item (Join-Path $sourceRoot "references\*") (Join-Path $targetRoot "references") -Recurse -Force
+Copy-Item (Join-Path $sourceRoot "assets\*") (Join-Path $targetRoot "assets\asu") -Recurse -Force
+Copy-Item (Join-Path $sourceRoot "references\*") (Join-Path $targetRoot "references\asu") -Recurse -Force
 ```
 
 **最终目录结构（`skills/` 下的每个 skill 必须含 `SKILL.md`）：**
@@ -44,11 +44,13 @@ Copy-Item (Join-Path $sourceRoot "references\*") (Join-Path $targetRoot "referen
 your-project/
 └── .claude/
     ├── assets/
-    │   ├── application-tracker.html
-    │   ├── templates-html/
-    │   └── ...
+    │   └── asu/
+    │       ├── application-tracker.html
+    │       ├── templates-html/
+    │       └── ...
     ├── references/
-    │   └── email-monitoring.md
+    │   └── asu/
+    │       └── email-monitoring.md
     └── skills/
         ├── asu/SKILL.md
         ├── contributor/SKILL.md
@@ -56,17 +58,66 @@ your-project/
         └── offer/SKILL.md
 ```
 
-安装后可在项目根目录运行以下检查，确认共享资源没有漏拷：
+安装后可在项目根目录运行以下检查，确认四个 skill 和共享资源没有漏拷。任一资源缺失都会输出路径并返回非零状态。
 
 ```bash
-test -f .claude/assets/application-tracker.html
-test -d .claude/assets/templates-html
-test -f .claude/references/email-monitoring.md
+required_paths=(
+  .claude/skills/asu/SKILL.md
+  .claude/skills/contributor/SKILL.md
+  .claude/skills/resume/SKILL.md
+  .claude/skills/offer/SKILL.md
+  .claude/assets/asu/application-tracker.html
+  .claude/assets/asu/application-tracker-overview.svg
+  .claude/assets/asu/templates-html
+  .claude/assets/asu/resume-data-template.json
+  .claude/assets/asu/resume-template-editable.html
+  .claude/assets/asu/resume-template-two-page.html
+  .claude/assets/asu/template-overview.jpg
+  .claude/assets/asu/fictional-resume-photo.png
+  .claude/references/asu/email-monitoring.md
+)
+missing=0
+for path in "${required_paths[@]}"; do
+  if [ ! -e "$path" ]; then
+    printf '缺少资源: %s\n' "$path" >&2
+    missing=1
+  fi
+done
+if [ "$missing" -ne 0 ]; then
+  exit 1
+fi
+printf 'ASu-skills 安装检查通过。\n'
+```
+
+Windows PowerShell 版：
+
+```powershell
+$requiredPaths = @(
+    ".claude\skills\asu\SKILL.md",
+    ".claude\skills\contributor\SKILL.md",
+    ".claude\skills\resume\SKILL.md",
+    ".claude\skills\offer\SKILL.md",
+    ".claude\assets\asu\application-tracker.html",
+    ".claude\assets\asu\application-tracker-overview.svg",
+    ".claude\assets\asu\templates-html",
+    ".claude\assets\asu\resume-data-template.json",
+    ".claude\assets\asu\resume-template-editable.html",
+    ".claude\assets\asu\resume-template-two-page.html",
+    ".claude\assets\asu\template-overview.jpg",
+    ".claude\assets\asu\fictional-resume-photo.png",
+    ".claude\references\asu\email-monitoring.md"
+)
+$missingPaths = @($requiredPaths | Where-Object { -not (Test-Path -LiteralPath $_) })
+if ($missingPaths.Count -gt 0) {
+    $missingPaths | ForEach-Object { Write-Error "缺少资源: $_" }
+    exit 1
+}
+Write-Output "ASu-skills 安装检查通过。"
 ```
 
 ### 方式 2：用户级安装（本机所有项目可用）
 
-共享资源也要复制到同一个 `.claude/` 根目录，不能只复制 `skills/`：
+共享资源也要复制到同一个 `.claude/` 根目录下的 ASu 命名空间，不能只复制 `skills/`：
 
 - macOS / Linux：`~/.claude/skills/`
 - Windows：`%USERPROFILE%\.claude\skills\`
@@ -77,10 +128,10 @@ test -f .claude/references/email-monitoring.md
 # 设置 ASu-skills 仓库路径
 asu_skills_dir=/path/to/ASu-skills
 
-mkdir -p ~/.claude/skills ~/.claude/assets ~/.claude/references
+mkdir -p ~/.claude/skills ~/.claude/assets/asu ~/.claude/references/asu
 cp -r "$asu_skills_dir/skills/."     ~/.claude/skills/
-cp -r "$asu_skills_dir/assets/."     ~/.claude/assets/
-cp -r "$asu_skills_dir/references/." ~/.claude/references/
+cp -r "$asu_skills_dir/assets/."     ~/.claude/assets/asu/
+cp -r "$asu_skills_dir/references/." ~/.claude/references/asu/
 ```
 
 Windows PowerShell 用户级安装：
@@ -88,10 +139,10 @@ Windows PowerShell 用户级安装：
 ```powershell
 $sourceRoot = "D:\DevProject\ASu-skills"
 $targetRoot = Join-Path $env:USERPROFILE ".claude"
-New-Item -ItemType Directory -Path (Join-Path $targetRoot "skills"),(Join-Path $targetRoot "assets"),(Join-Path $targetRoot "references") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $targetRoot "skills"),(Join-Path $targetRoot "assets\asu"),(Join-Path $targetRoot "references\asu") -Force | Out-Null
 Copy-Item (Join-Path $sourceRoot "skills\*") (Join-Path $targetRoot "skills") -Recurse -Force
-Copy-Item (Join-Path $sourceRoot "assets\*") (Join-Path $targetRoot "assets") -Recurse -Force
-Copy-Item (Join-Path $sourceRoot "references\*") (Join-Path $targetRoot "references") -Recurse -Force
+Copy-Item (Join-Path $sourceRoot "assets\*") (Join-Path $targetRoot "assets\asu") -Recurse -Force
+Copy-Item (Join-Path $sourceRoot "references\*") (Join-Path $targetRoot "references\asu") -Recurse -Force
 ```
 
 
@@ -126,9 +177,9 @@ Claude Code 根据 `description` 自动匹配技能，直接说人话即可：
 | 事项 | 说明 |
 | --- | --- |
 | `agents/openai.yaml` | Codex 专属配置，Claude Code 会忽略，保留或删除均可 |
-| `/contributor` 权限 | 先只读扫描并展示 diff；fork、push 和提交 PR 前逐个明确确认，使用最小 Git/GitHub 权限，不要使用 `--dangerously-skip-permissions` |
+| `/contributor` 权限 | 本安装文档不授予远端写权限；具体授权以最新版 contributor skill 的逐项确认规则为准，未确认前只做只读扫描和本地 diff，使用最小 Git/GitHub 权限，不要使用 `--dangerously-skip-permissions` |
 | 项目级安装与 git | `.claude/skills` 默认会进 git，适合团队共享；若只想自己用，请改用方式 2 或加入 `.gitignore` |
-| 路径问题 | `resume` 和 `offer` 依赖 `.claude/assets`、`.claude/references`，必须复制共享资源，不要只拷 `SKILL.md` 或四个 skill 文件夹 |
+| 路径问题 | `resume` 和 `offer` 依赖 `.claude/assets/asu`、`.claude/references/asu`，必须复制共享资源，不要只拷 `SKILL.md` 或四个 skill 文件夹 |
 
 ## 六、卸载
 
@@ -142,6 +193,30 @@ rm -rf .claude/skills/asu .claude/skills/contributor .claude/skills/resume .clau
 rm -rf ~/.claude/skills/asu ~/.claude/skills/contributor ~/.claude/skills/resume ~/.claude/skills/offer
 ```
 
+上面的命令不会删除共享资源，因为 `application-tracker.html` 可能包含用户编辑内容。确认不需要这些 ASu 资源后，再分别执行：
+
+```bash
+shared_paths=(
+  .claude/assets/asu
+  .claude/references/asu
+  "${HOME}/.claude/assets/asu"
+  "${HOME}/.claude/references/asu"
+)
+existing_paths=()
+for path in "${shared_paths[@]}"; do
+  [ -e "$path" ] && existing_paths+=("$path")
+done
+if [ "${#existing_paths[@]}" -gt 0 ]; then
+  printf '将删除以下 ASu 共享资源:\n%s\n' "${existing_paths[*]}"
+  read -r -p '确认删除请输入 DELETE，否则保留: ' answer
+  if [ "$answer" = "DELETE" ]; then
+    rm -rf -- "${existing_paths[@]}"
+  else
+    printf '已保留 ASu 共享资源。\n'
+  fi
+fi
+```
+
 Windows PowerShell：
 
 ```powershell
@@ -150,5 +225,26 @@ Remove-Item -Path .claude\skills\asu,.claude\skills\contributor,.claude\skills\r
 
 # 用户级
 Remove-Item -Path "$env:USERPROFILE\.claude\skills\asu","$env:USERPROFILE\.claude\skills\contributor","$env:USERPROFILE\.claude\skills\resume","$env:USERPROFILE\.claude\skills\offer" -Recurse -Force
+```
+
+上面的命令不会删除共享资源。确认不需要这些 ASu 资源后，再运行以下 PowerShell 清理命令；输入 `DELETE` 以确认，其他输入都会保留资源：
+
+```powershell
+$sharedPaths = @(
+    (Join-Path (Get-Location) ".claude\assets\asu"),
+    (Join-Path (Get-Location) ".claude\references\asu"),
+    (Join-Path $env:USERPROFILE ".claude\assets\asu"),
+    (Join-Path $env:USERPROFILE ".claude\references\asu")
+)
+$existingPaths = @($sharedPaths | Where-Object { Test-Path -LiteralPath $_ })
+if ($existingPaths.Count -gt 0) {
+    $existingPaths | ForEach-Object { Write-Output "将删除: $_" }
+    $answer = Read-Host "确认删除请输入 DELETE，否则保留"
+    if ($answer -eq "DELETE") {
+        Remove-Item -LiteralPath $existingPaths -Recurse -Force
+    } else {
+        Write-Output "已保留 ASu 共享资源。"
+    }
+}
 ```
 

--- a/Install-In-ClaudeCode.md
+++ b/Install-In-ClaudeCode.md
@@ -12,31 +12,43 @@
 把 skills 放进你的工作项目根目录的 `.claude/skills/`：
 
 ```bash
+# 设置 ASu-skills 仓库路径
+asu_skills_dir=/path/to/ASu-skills
+
 # 进入你的工作项目
 cd /path/to/your-project
 
-# 创建目录
-mkdir -p .claude/skills
+# 创建 skill 和共享资源目录
+mkdir -p .claude/skills .claude/assets .claude/references
 
-# 复制四个 skill
-cp -r ./skills/asu          .claude/skills/
-cp -r ./skills/contributor  .claude/skills/
-cp -r ./skills/resume       .claude/skills/
-cp -r ./skills/offer        .claude/skills/
+# 复制四个 skill 和共享资源
+cp -r "$asu_skills_dir/skills/."     .claude/skills/
+cp -r "$asu_skills_dir/assets/."     .claude/assets/
+cp -r "$asu_skills_dir/references/." .claude/references/
 ```
 
 Windows PowerShell 版：
 
 ```powershell
-New-Item -ItemType Directory -Path .claude/skills -Force | Out-Null
-Copy-Item "D:\DevProject\ASu-skills\skills\asu","D:\DevProject\ASu-skills\skills\contributor","D:\DevProject\ASu-skills\skills\resume","D:\DevProject\ASu-skills\skills\offer" -Destination .claude/skills -Recurse
+$sourceRoot = "D:\DevProject\ASu-skills"
+$targetRoot = Join-Path (Get-Location) ".claude"
+New-Item -ItemType Directory -Path (Join-Path $targetRoot "skills"),(Join-Path $targetRoot "assets"),(Join-Path $targetRoot "references") -Force | Out-Null
+Copy-Item (Join-Path $sourceRoot "skills\*") (Join-Path $targetRoot "skills") -Recurse -Force
+Copy-Item (Join-Path $sourceRoot "assets\*") (Join-Path $targetRoot "assets") -Recurse -Force
+Copy-Item (Join-Path $sourceRoot "references\*") (Join-Path $targetRoot "references") -Recurse -Force
 ```
 
-**最终目录结构（每项必须含 `SKILL.md`）：**
+**最终目录结构（`skills/` 下的每个 skill 必须含 `SKILL.md`）：**
 
 ```text
 your-project/
 └── .claude/
+    ├── assets/
+    │   ├── application-tracker.html
+    │   ├── templates-html/
+    │   └── ...
+    ├── references/
+    │   └── email-monitoring.md
     └── skills/
         ├── asu/SKILL.md
         ├── contributor/SKILL.md
@@ -44,14 +56,43 @@ your-project/
         └── offer/SKILL.md
 ```
 
+安装后可在项目根目录运行以下检查，确认共享资源没有漏拷：
+
+```bash
+test -f .claude/assets/application-tracker.html
+test -d .claude/assets/templates-html
+test -f .claude/references/email-monitoring.md
+```
+
 ### 方式 2：用户级安装（本机所有项目可用）
 
-复制位置改为：
+共享资源也要复制到同一个 `.claude/` 根目录，不能只复制 `skills/`：
 
 - macOS / Linux：`~/.claude/skills/`
 - Windows：`%USERPROFILE%\.claude\skills\`
 
-命令同上，把目标目录换成上面路径即可。
+例如 macOS / Linux：
+
+```bash
+# 设置 ASu-skills 仓库路径
+asu_skills_dir=/path/to/ASu-skills
+
+mkdir -p ~/.claude/skills ~/.claude/assets ~/.claude/references
+cp -r "$asu_skills_dir/skills/."     ~/.claude/skills/
+cp -r "$asu_skills_dir/assets/."     ~/.claude/assets/
+cp -r "$asu_skills_dir/references/." ~/.claude/references/
+```
+
+Windows PowerShell 用户级安装：
+
+```powershell
+$sourceRoot = "D:\DevProject\ASu-skills"
+$targetRoot = Join-Path $env:USERPROFILE ".claude"
+New-Item -ItemType Directory -Path (Join-Path $targetRoot "skills"),(Join-Path $targetRoot "assets"),(Join-Path $targetRoot "references") -Force | Out-Null
+Copy-Item (Join-Path $sourceRoot "skills\*") (Join-Path $targetRoot "skills") -Recurse -Force
+Copy-Item (Join-Path $sourceRoot "assets\*") (Join-Path $targetRoot "assets") -Recurse -Force
+Copy-Item (Join-Path $sourceRoot "references\*") (Join-Path $targetRoot "references") -Recurse -Force
+```
 
 
 ## 三、验证安装
@@ -85,9 +126,9 @@ Claude Code 根据 `description` 自动匹配技能，直接说人话即可：
 | 事项 | 说明 |
 | --- | --- |
 | `agents/openai.yaml` | Codex 专属配置，Claude Code 会忽略，保留或删除均可 |
-| `/contributor` 权限 | 自动 fork + 提 PR 需要 git/GitHub CLI 权限，可用 `/permissions` 授权，或启动时加 `--dangerously-skip-permissions`（不推荐） |
+| `/contributor` 权限 | 先只读扫描并展示 diff；fork、push 和提交 PR 前逐个明确确认，使用最小 Git/GitHub 权限，不要使用 `--dangerously-skip-permissions` |
 | 项目级安装与 git | `.claude/skills` 默认会进 git，适合团队共享；若只想自己用，请改用方式 2 或加入 `.gitignore` |
-| 路径问题 | 技能目录内若有相对路径引用资源（如 `resume` 引用的模板），确保整个 skill 文件夹完整复制，不要只拷 `SKILL.md` |
+| 路径问题 | `resume` 和 `offer` 依赖 `.claude/assets`、`.claude/references`，必须复制共享资源，不要只拷 `SKILL.md` 或四个 skill 文件夹 |
 
 ## 六、卸载
 
@@ -110,3 +151,4 @@ Remove-Item -Path .claude\skills\asu,.claude\skills\contributor,.claude\skills\r
 # 用户级
 Remove-Item -Path "$env:USERPROFILE\.claude\skills\asu","$env:USERPROFILE\.claude\skills\contributor","$env:USERPROFILE\.claude\skills\resume","$env:USERPROFILE\.claude\skills\offer" -Recurse -Force
 ```
+

--- a/Install-In-ClaudeCode.md
+++ b/Install-In-ClaudeCode.md
@@ -76,6 +76,10 @@ required_paths=(
   .claude/assets/asu/fictional-resume-photo.png
   .claude/references/asu/email-monitoring.md
 )
+# 18 个内置简历模板必须全部存在，不能只检查目录。
+for template_number in {01..18}; do
+  required_paths+=(".claude/assets/asu/templates-html/${template_number}-大厂极简简历模板.html")
+done
 missing=0
 for path in "${required_paths[@]}"; do
   if [ ! -e "$path" ]; then
@@ -107,6 +111,10 @@ $requiredPaths = @(
     ".claude\assets\asu\fictional-resume-photo.png",
     ".claude\references\asu\email-monitoring.md"
 )
+# 18 个内置简历模板必须全部存在，不能只检查目录。
+1..18 | ForEach-Object {
+    $requiredPaths += (".claude\assets\asu\templates-html\{0:D2}-大厂极简简历模板.html" -f $_)
+}
 $missingPaths = @($requiredPaths | Where-Object { -not (Test-Path -LiteralPath $_) })
 if ($missingPaths.Count -gt 0) {
     $missingPaths | ForEach-Object { Write-Error "缺少资源: $_" }
@@ -193,26 +201,48 @@ rm -rf .claude/skills/asu .claude/skills/contributor .claude/skills/resume .clau
 rm -rf ~/.claude/skills/asu ~/.claude/skills/contributor ~/.claude/skills/resume ~/.claude/skills/offer
 ```
 
-上面的命令不会删除共享资源，因为 `application-tracker.html` 可能包含用户编辑内容。确认不需要这些 ASu 资源后，再分别执行：
+上面的命令不会删除共享资源，因为 `application-tracker.html` 可能包含用户编辑内容。根据要卸载的作用域，选择下面对应的一段；每段只删除 ASu 命名空间，并要求独立输入 `DELETE` 确认。
+
+只卸载当前项目的共享资源：
 
 ```bash
-shared_paths=(
+project_shared_paths=(
   .claude/assets/asu
   .claude/references/asu
+)
+project_existing_paths=()
+for path in "${project_shared_paths[@]}"; do
+  [ -e "$path" ] && project_existing_paths+=("$path")
+done
+if [ "${#project_existing_paths[@]}" -gt 0 ]; then
+  printf '将删除项目级 ASu 共享资源:\n%s\n' "${project_existing_paths[*]}"
+  read -r -p '确认删除请输入 DELETE，否则保留: ' answer
+  if [ "$answer" = "DELETE" ]; then
+    rm -rf -- "${project_existing_paths[@]}"
+  else
+    printf '已保留项目级 ASu 共享资源。\n'
+  fi
+fi
+```
+
+只卸载用户级共享资源（不会影响项目级资源）：
+
+```bash
+user_shared_paths=(
   "${HOME}/.claude/assets/asu"
   "${HOME}/.claude/references/asu"
 )
-existing_paths=()
-for path in "${shared_paths[@]}"; do
-  [ -e "$path" ] && existing_paths+=("$path")
+user_existing_paths=()
+for path in "${user_shared_paths[@]}"; do
+  [ -e "$path" ] && user_existing_paths+=("$path")
 done
-if [ "${#existing_paths[@]}" -gt 0 ]; then
-  printf '将删除以下 ASu 共享资源:\n%s\n' "${existing_paths[*]}"
+if [ "${#user_existing_paths[@]}" -gt 0 ]; then
+  printf '将删除用户级 ASu 共享资源:\n%s\n' "${user_existing_paths[*]}"
   read -r -p '确认删除请输入 DELETE，否则保留: ' answer
   if [ "$answer" = "DELETE" ]; then
-    rm -rf -- "${existing_paths[@]}"
+    rm -rf -- "${user_existing_paths[@]}"
   else
-    printf '已保留 ASu 共享资源。\n'
+    printf '已保留用户级 ASu 共享资源。\n'
   fi
 fi
 ```
@@ -227,23 +257,42 @@ Remove-Item -Path .claude\skills\asu,.claude\skills\contributor,.claude\skills\r
 Remove-Item -Path "$env:USERPROFILE\.claude\skills\asu","$env:USERPROFILE\.claude\skills\contributor","$env:USERPROFILE\.claude\skills\resume","$env:USERPROFILE\.claude\skills\offer" -Recurse -Force
 ```
 
-上面的命令不会删除共享资源。确认不需要这些 ASu 资源后，再运行以下 PowerShell 清理命令；输入 `DELETE` 以确认，其他输入都会保留资源：
+上面的命令不会删除共享资源。根据要卸载的作用域，选择下面对应的 PowerShell 片段；输入 `DELETE` 以确认，其他输入都会保留资源：
+
+只卸载当前项目的共享资源：
 
 ```powershell
-$sharedPaths = @(
+$projectSharedPaths = @(
     (Join-Path (Get-Location) ".claude\assets\asu"),
-    (Join-Path (Get-Location) ".claude\references\asu"),
+    (Join-Path (Get-Location) ".claude\references\asu")
+)
+$projectExistingPaths = @($projectSharedPaths | Where-Object { Test-Path -LiteralPath $_ })
+if ($projectExistingPaths.Count -gt 0) {
+    $projectExistingPaths | ForEach-Object { Write-Output "将删除项目级资源: $_" }
+    $answer = Read-Host "确认删除请输入 DELETE，否则保留"
+    if ($answer -eq "DELETE") {
+        Remove-Item -LiteralPath $projectExistingPaths -Recurse -Force
+    } else {
+        Write-Output "已保留项目级 ASu 共享资源。"
+    }
+}
+```
+
+只卸载用户级共享资源（不会影响项目级资源）：
+
+```powershell
+$userSharedPaths = @(
     (Join-Path $env:USERPROFILE ".claude\assets\asu"),
     (Join-Path $env:USERPROFILE ".claude\references\asu")
 )
-$existingPaths = @($sharedPaths | Where-Object { Test-Path -LiteralPath $_ })
-if ($existingPaths.Count -gt 0) {
-    $existingPaths | ForEach-Object { Write-Output "将删除: $_" }
+$userExistingPaths = @($userSharedPaths | Where-Object { Test-Path -LiteralPath $_ })
+if ($userExistingPaths.Count -gt 0) {
+    $userExistingPaths | ForEach-Object { Write-Output "将删除用户级资源: $_" }
     $answer = Read-Host "确认删除请输入 DELETE，否则保留"
     if ($answer -eq "DELETE") {
-        Remove-Item -LiteralPath $existingPaths -Recurse -Force
+        Remove-Item -LiteralPath $userExistingPaths -Recurse -Force
     } else {
-        Write-Output "已保留 ASu 共享资源。"
+        Write-Output "已保留用户级 ASu 共享资源。"
     }
 }
 ```

--- a/skills/offer/SKILL.md
+++ b/skills/offer/SKILL.md
@@ -9,9 +9,9 @@ description: 中文秋招求职进度管理技能：记录和更新投递、筛�
 
 ## 资源定位
 
-本 skill 位于插件的 `skills/offer/` 目录时，共享资源位于 `../../assets/`，其中 `application-tracker.html` 是可编辑的求职进度表，`application-tracker-overview.svg` 是预览图。需要整理招聘邮箱时，先读取 `../../references/email-monitoring.md`。
+本 skill 位于插件的 `skills/offer/` 目录时，ASu 共享资源位于命名空间目录 `../../assets/asu/`，其中 `application-tracker.html` 是可编辑的求职进度表，`application-tracker-overview.svg` 是预览图。需要整理招聘邮箱时，先读取 `../../references/asu/email-monitoring.md`。
 
-如果 skill 被单独复制到其他目录，先从当前 skill 目录向上定位 `assets/` 和 `references/`，不要重新制作已有资源。
+如果 skill 被单独复制到其他目录，先从当前 skill 目录向上定位 `assets/asu/` 和 `references/asu/`，不要重新制作已有资源。
 
 ## 工作流程
 
@@ -29,3 +29,4 @@ description: 中文秋招求职进度管理技能：记录和更新投递、筛�
 ## 默认交付
 
 默认提供进度表文件、已识别记录摘要、状态变化、下一步清单和缺失信息。不要把用户的真实求职记录写进 skill 的模板或 README。
+

--- a/skills/offer/SKILL.md
+++ b/skills/offer/SKILL.md
@@ -9,9 +9,9 @@ description: 中文秋招求职进度管理技能：记录和更新投递、筛�
 
 ## 资源定位
 
-本 skill 位于插件的 `skills/offer/` 目录时，ASu 共享资源位于命名空间目录 `../../assets/asu/`，其中 `application-tracker.html` 是可编辑的求职进度表，`application-tracker-overview.svg` 是预览图。需要整理招聘邮箱时，先读取 `../../references/asu/email-monitoring.md`。
+ASu 资源支持两种布局，按以下顺序定位：Claude Code 安装布局使用 `../../assets/asu/` 与 `../../references/asu/`；仓库插件布局使用 `../../assets/` 与 `../../references/`。只有候选路径同时包含 `application-tracker.html`、`application-tracker-overview.svg` 和 `email-monitoring.md` 时才使用它，避免误用其他 skill 的资源。`application-tracker.html` 是可编辑的求职进度表，`application-tracker-overview.svg` 是预览图。
 
-如果 skill 被单独复制到其他目录，先从当前 skill 目录向上定位 `assets/asu/` 和 `references/asu/`，不要重新制作已有资源。
+如果 skill 被单独复制到其他目录，先从当前 skill 目录向上依次定位 `assets/asu/`、`references/asu/` 与仓库插件的 `assets/`、`references/`，不要重新制作已有资源。
 
 ## 工作流程
 

--- a/skills/offer/SKILL.md
+++ b/skills/offer/SKILL.md
@@ -9,7 +9,7 @@ description: 中文秋招求职进度管理技能：记录和更新投递、筛�
 
 ## 资源定位
 
-ASu 资源支持两种布局，按以下顺序定位：Claude Code 安装布局使用 `../../assets/asu/` 与 `../../references/asu/`；仓库插件布局使用 `../../assets/` 与 `../../references/`。只有候选路径同时包含 `application-tracker.html`、`application-tracker-overview.svg` 和 `email-monitoring.md` 时才使用它，避免误用其他 skill 的资源。`application-tracker.html` 是可编辑的求职进度表，`application-tracker-overview.svg` 是预览图。
+ASu 资源支持两种布局，按以下顺序定位：Claude Code 安装布局使用 `../../assets/asu/` 与 `../../references/asu/`；仓库插件布局使用 `../../assets/` 与 `../../references/`。每个候选均为一对 assets/references 目录：仅当 assets 目录同时包含 `application-tracker.html` 和 `application-tracker-overview.svg`，且对应 references 目录包含 `email-monitoring.md` 时才使用该目录对，避免误用其他 skill 的资源。`application-tracker.html` 是可编辑的求职进度表，`application-tracker-overview.svg` 是预览图。
 
 如果 skill 被单独复制到其他目录，先从当前 skill 目录向上依次定位 `assets/asu/`、`references/asu/` 与仓库插件的 `assets/`、`references/`，不要重新制作已有资源。
 
@@ -29,4 +29,3 @@ ASu 资源支持两种布局，按以下顺序定位：Claude Code 安装布局�
 ## 默认交付
 
 默认提供进度表文件、已识别记录摘要、状态变化、下一步清单和缺失信息。不要把用户的真实求职记录写进 skill 的模板或 README。
-

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -10,7 +10,12 @@ description: 中文可编辑简历制作技能：根据用户经历选择或复�
 
 ## 资源定位
 
-本 skill 位于插件的 `skills/resume/` 目录时，ASu 共享资源位于命名空间目录 `../../assets/asu/`：
+ASu 资源支持两种布局，按以下顺序定位：
+
+1. Claude Code 安装布局：`../../assets/asu/`；
+2. 仓库插件布局：`../../assets/`。
+
+只有候选目录同时包含 `resume-data-template.json`、`templates-html/` 和 `resume-template-editable.html` 时才使用它，避免把其他 skill 的同名目录误判为 ASu 资源：
 
 - `resume-data-template.json`：匿名简历内容结构；
 - `templates-html/`：18 个中文 HTML 模板；
@@ -19,9 +24,9 @@ description: 中文可编辑简历制作技能：根据用户经历选择或复�
 - `template-overview.jpg`：模板预览图；
 - `fictional-resume-photo.png`：虚构示例照片，只用于模板演示。
 
-如果 skill 被单独复制到其他目录，先从当前 skill 目录向上定位 `assets/asu/`，不要凭空创建模板资源。
+如果 skill 被单独复制到其他目录，先从当前 skill 目录向上依次定位 `assets/asu/` 与 `assets/`，不要凭空创建模板资源。
 
-如果向上查找后仍找不到 `assets/asu/`，必须显式说明“模板资源未随 skill 一起安装”，并启用后备方案：
+如果向上查找后两种布局都找不到完整资源，必须显式说明“模板资源未随 skill 一起安装”，并启用后备方案：
 
 - 优先创建简洁 A4 可编辑 HTML，保留浏览器编辑、打印隐藏工具栏和 PDF 导出能力；
 - 不承诺 18 套模板、模板预览图、示例照片或原模板复刻精度；

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -10,7 +10,7 @@ description: 中文可编辑简历制作技能：根据用户经历选择或复�
 
 ## 资源定位
 
-本 skill 位于插件的 `skills/resume/` 目录时，共享资源位于 `../../assets/`：
+本 skill 位于插件的 `skills/resume/` 目录时，ASu 共享资源位于命名空间目录 `../../assets/asu/`：
 
 - `resume-data-template.json`：匿名简历内容结构；
 - `templates-html/`：18 个中文 HTML 模板；
@@ -19,9 +19,9 @@ description: 中文可编辑简历制作技能：根据用户经历选择或复�
 - `template-overview.jpg`：模板预览图；
 - `fictional-resume-photo.png`：虚构示例照片，只用于模板演示。
 
-如果 skill 被单独复制到其他目录，先从当前 skill 目录向上定位 `assets/`，不要凭空创建模板资源。
+如果 skill 被单独复制到其他目录，先从当前 skill 目录向上定位 `assets/asu/`，不要凭空创建模板资源。
 
-如果向上查找后仍找不到 `assets/`，必须显式说明“模板资源未随 skill 一起安装”，并启用后备方案：
+如果向上查找后仍找不到 `assets/asu/`，必须显式说明“模板资源未随 skill 一起安装”，并启用后备方案：
 
 - 优先创建简洁 A4 可编辑 HTML，保留浏览器编辑、打印隐藏工具栏和 PDF 导出能力；
 - 不承诺 18 套模板、模板预览图、示例照片或原模板复刻精度；
@@ -113,3 +113,4 @@ PDF 不是简单“能保存”即可。导出或指导用户导出时，按以�
 ## 交付内容
 
 默认交付：可编辑 `.html` 文件、使用的模板说明、资源/fallback 状态、print-preview QA 结果、浏览器编辑方法和 PDF 导出方法。若用户同时需要经历改写，先调用 `/asu` 完成文字，再将确认后的内容放入简历。
+

--- a/skills/resume/SKILL.md
+++ b/skills/resume/SKILL.md
@@ -15,7 +15,7 @@ ASu 资源支持两种布局，按以下顺序定位：
 1. Claude Code 安装布局：`../../assets/asu/`；
 2. 仓库插件布局：`../../assets/`。
 
-只有候选目录同时包含 `resume-data-template.json`、`templates-html/` 和 `resume-template-editable.html` 时才使用它，避免把其他 skill 的同名目录误判为 ASu 资源：
+只有候选目录同时包含 `resume-data-template.json`、`resume-template-editable.html`、`resume-template-two-page.html`、`template-overview.jpg`、`fictional-resume-photo.png`，以及 `templates-html/` 下全部 18 个内置模板时才使用它，避免把其他 skill 的同名目录或不完整安装误判为 ASu 资源：
 
 - `resume-data-template.json`：匿名简历内容结构；
 - `templates-html/`：18 个中文 HTML 模板；
@@ -118,4 +118,3 @@ PDF 不是简单“能保存”即可。导出或指导用户导出时，按以�
 ## 交付内容
 
 默认交付：可编辑 `.html` 文件、使用的模板说明、资源/fallback 状态、print-preview QA 结果、浏览器编辑方法和 PDF 导出方法。若用户同时需要经历改写，先调用 `/asu` 完成文字，再将确认后的内容放入简历。
-


### PR DESCRIPTION
## 中文说明

### 这次改了什么

这个 PR 让 ASu-skills 在 Claude Code 中的安装和更新更稳妥。

安装时除了四个 skill，还会把简历模板、求职进度表和邮件整理说明一起放到 ASu 自己的资源目录中，因此不会误用其他 skill 的同名文件。

如果用户已经在 application-tracker.html 里记录了求职进度，再次安装或更新前会自动创建一个不会覆盖的 .bak 备份。这样更新共享资源不会把用户自己填写的内容冲掉。

同时，resume 和 offer 在寻找资源时会做更完整的检查：

- resume 只有在简历数据文件、单页和双页模板、预览图、示例照片，以及全部 18 个 HTML 模板都存在时，才认为资源安装完整；
- offer 会把进度表文件所在的 assets 目录与邮件说明所在的 references 目录作为一对来检查，不会因为它们不在同一个目录而误判安装失败。

项目级和用户级的卸载说明也分开了：每一段都只删除 ASu 自己的命名空间，并要求输入 DELETE 才会执行。

### 为什么这样改

用户更新 skill 时，最不应该发生的是丢掉自己填过的求职记录，或在运行到一半时才发现模板、图片或邮件说明并没有装全。这些改动让安装结果更容易验证，失败时也能明确知道缺少什么。

### 验证

- PowerShell 文档代码块 AST 解析通过：6/6。
- 18 个预期简历模板和关键资源均已检查存在。
- git diff --check 通过。

---

## English Description

### What changed

This PR makes ASu-skills safer and more predictable to install and update in Claude Code.

Installation now places the four skills, resume templates, application tracker, and email-monitoring reference in ASu's own resource directories. This avoids accidentally picking up a same-named file from another skill.

If a user has already filled in application-tracker.html, a reinstall or update creates a non-overwriting .bak backup before replacing it. Shared resources can be updated without losing the user's job-search record.

The resume and offer skills also perform clearer completeness checks:

- resume treats the installation as complete only when the data file, single- and two-page templates, preview image, example photo, and all 18 HTML templates are present;
- offer checks the assets directory containing the tracker together with the matching references directory containing the email guide, rather than incorrectly expecting all files in one directory.

Project-level and user-level uninstall instructions are now separate. Each removes only ASu's own namespace and requires the user to type DELETE first.

### Why

Updating a skill should not erase a user's job-search record or fail halfway through because templates, images, or supporting documentation were only partially installed. These changes make the installation easier to verify and make missing resources obvious.

### Validation

- All six PowerShell code blocks passed AST parsing.
- All 18 expected resume templates and critical resources were verified present.
- git diff --check passed.
