### PR TITLE
feat: 支持投递记录合并导入

### DIFF
--- a/assets/application-tracker.html
+++ b/assets/application-tracker.html
@@ -144,12 +144,14 @@
         <p>把每一次投递、面试和反馈都记录下来，随时掌握求职节奏。</p>
       </div>
       <div class="hero-actions">
-        <button class="button secondary" id="importButton" type="button">导入备份</button>
+        <button class="button secondary" id="importButton" type="button">覆盖导入</button>
+        <button class="button secondary" id="mergeImportButton" type="button">合并导入</button>
         <button class="button secondary" id="exportJsonButton" type="button">备份 JSON</button>
         <button class="button secondary" id="exportCsvButton" type="button">导出 CSV</button>
         <button class="button secondary" id="printButton" type="button">打印 / PDF</button>
         <button class="button" id="addButton" type="button">＋ 新增记录</button>
         <input id="importInput" type="file" accept="application/json,.json" hidden>
+        <input id="mergeImportInput" type="file" accept="application/json,.json" hidden>
       </div>
     </header>
 
@@ -230,10 +232,39 @@
           const saved = localStorage.getItem(STORAGE_KEY);
           if (!saved) return initialRecords.map((item) => ({ ...item }));
           const value = JSON.parse(saved);
-          return Array.isArray(value) ? value.map((item) => ({ ...item, time: item.time || '' })) : initialRecords.map((item) => ({ ...item }));
+          return Array.isArray(value) ? value.map(normalizeRecord).filter((item) => item.company) : initialRecords.map((item) => ({ ...item }));
         } catch { return initialRecords.map((item) => ({ ...item })); }
       }
       function persist() { localStorage.setItem(STORAGE_KEY, JSON.stringify(records)); }
+      function normalizeRecord(item) {
+        return {
+          id: item.id || makeId(),
+          date: item.date || today(),
+          time: String(item.time || ''),
+          company: String(item.company || '').trim(),
+          position: String(item.position || '').trim(),
+          status: statuses.includes(item.status) ? item.status : '已投递',
+          next: String(item.next || ''),
+          note: String(item.note || ''),
+          updatedAt: item.updatedAt || `${item.date || ''}T${item.time || ''}`
+        };
+      }
+      function recordKey(item) {
+        return `${item.company.replace(/\s+/g, '').toLocaleLowerCase('zh-CN')}\u0000${item.position.replace(/\s+/g, '').toLocaleLowerCase('zh-CN')}`;
+      }
+      function recency(item) { return item.updatedAt || `${item.date || ''}T${item.time || ''}`; }
+      function mergeRecords(current, incoming) {
+        const byKey = new Map(current.map((item) => [recordKey(item), item]));
+        let added = 0;
+        let updated = 0;
+        for (const item of incoming) {
+          const key = recordKey(item);
+          const previous = byKey.get(key);
+          if (!previous) { byKey.set(key, item); added += 1; continue; }
+          if (recency(item) >= recency(previous)) { byKey.set(key, { ...previous, ...item, id: previous.id }); updated += 1; }
+        }
+        return { records: [...byKey.values()], added, updated };
+      }
       function escapeHtml(value) {
         return String(value ?? '').replace(/[&<>'"]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[char]));
       }
@@ -312,14 +343,21 @@
         const csv = [header, ...rows].map((row) => row.map((cell) => `"${String(cell ?? '').replace(/"/g, '""')}"`).join(',')).join('\n');
         download(`秋招投递进度-${today()}.csv`, '\ufeff' + csv, 'text/csv;charset=utf-8');
       }
-      function importJson(file) {
+      function importJson(file, mode = 'replace') {
         const reader = new FileReader();
         reader.onload = () => {
           try {
             const value = JSON.parse(reader.result);
             if (!Array.isArray(value)) throw new Error('格式错误');
-            records = value.filter((item) => item && item.company).map((item) => ({ id: item.id || makeId(), date: item.date || today(), time: String(item.time || ''), company: String(item.company), position: String(item.position || ''), status: statuses.includes(item.status) ? item.status : '已投递', next: String(item.next || ''), note: String(item.note || '') }));
-            persist(); render(); alert(`已导入 ${records.length} 条记录。`);
+            const incoming = value.filter((item) => item && item.company).map(normalizeRecord);
+            if (mode === 'merge') {
+              const result = mergeRecords(records, incoming);
+              records = result.records;
+              persist(); render(); alert(`已合并 ${incoming.length} 条备份：新增 ${result.added} 条，更新 ${result.updated} 条。`);
+            } else {
+              records = incoming;
+              persist(); render(); alert(`已覆盖导入 ${records.length} 条记录。`);
+            }
           } catch { alert('导入失败：请选择本页面导出的 JSON 备份文件。'); }
         };
         reader.readAsText(file, 'utf-8');
@@ -336,19 +374,21 @@
       $('#printButton').addEventListener('click', () => window.print());
       $('#exportCsvButton').addEventListener('click', exportCsv);
       $('#importButton').addEventListener('click', () => $('#importInput').click());
+      $('#mergeImportButton').addEventListener('click', () => $('#mergeImportInput').click());
       $('#exportJsonButton').addEventListener('click', () => {
         const backup = JSON.stringify(records, null, 2);
         download(`秋招投递进度备份-${today()}.json`, backup, 'application/json;charset=utf-8');
       });
-      $('#importInput').addEventListener('change', (event) => { if (event.target.files[0]) importJson(event.target.files[0]); event.target.value = ''; });
+      $('#importInput').addEventListener('change', (event) => { if (event.target.files[0] && confirm('覆盖导入会替换当前全部记录，确定继续吗？')) importJson(event.target.files[0]); event.target.value = ''; });
+      $('#mergeImportInput').addEventListener('change', (event) => { if (event.target.files[0]) importJson(event.target.files[0], 'merge'); event.target.value = ''; });
       form.addEventListener('submit', (event) => {
         event.preventDefault();
         const data = { date: dateInput.value, time: timeInput.value, company: companyInput.value.trim(), position: positionInput.value.trim(), status: statusInput.value, next: nextInput.value.trim(), note: noteInput.value.trim() };
         if (!data.company) return companyInput.focus();
         if (editingId) {
           const index = records.findIndex((item) => item.id === editingId);
-          if (index >= 0) records[index] = { ...records[index], ...data };
-        } else records.push({ id: makeId(), ...data });
+          if (index >= 0) records[index] = { ...records[index], ...data, updatedAt: new Date().toISOString() };
+        } else records.push({ id: makeId(), ...data, updatedAt: new Date().toISOString() });
         persist(); render(); closeModal();
       });
       body.addEventListener('click', (event) => {


### PR DESCRIPTION
## 变更说明

为本地离线的秋招投递进度表增加安全的“合并导入”能力，避免从备份恢复时直接覆盖已积累的记录。

## 变更类型

- [x] `feat`：新增功能或资源

## 关联问题

无。

## 实现内容

- 主要改动：新增“合并导入”入口；以“公司 + 岗位”作为去重键；对重复记录保留更新时间更晚的数据；展示新增和更新计数。
- 改动原因：现有 JSON 导入会覆盖全部本地记录，用户跨设备/多份备份整理时存在数据丢失风险。
- 影响范围：仅 `assets/application-tracker.html`；原有覆盖导入保留，并增加确认提示。

## 检查清单

- [x] 已阅读根目录 `AGENTS.md`
- [x] 已阅读根目录 `CONTRIBUTING.md`
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已运行 `git diff --check`
- [x] 已检查修改内容中没有冲突标记
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已完成与本次改动相关的自动化检查
- [x] 不涉及 HTML 模板、图片或 Logo 资源规则变更

## 验证结果

```text
git diff --check 通过
node --check（抽取页面内 JavaScript）通过
合并逻辑 smoke test 通过：重复记录更新 1 条、新记录新增 1 条，并保留本地记录 ID。
```

## 额外说明

兼容旧备份：缺少 `updatedAt` 的记录回退使用原有日期/时间参与比较。
