### PR TITLE
docs: 增加新用户 Skill 选择指引

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ ASu-skills 现在是一个插件包。安装后会提供五个可单独调用的
 | `/asu-resume`  | 同款简历 | 复刻 ASu 单栏高密度技术简历、Logo 资源和 PDF  |
 | `/offer`       | 秋招进度 | 投递、测评、面试、Offer、拒信和招聘邮件跟踪   |
 
+## 第一次使用：从哪个入口开始
+
+先根据当前最需要解决的问题选择第一个入口：
+
+| 当前情况 | 建议先使用 |
+| -------- | ---------- |
+| 缺少可验证的项目或协作经历 | `/contributor` |
+| 已有经历，但不知道如何匹配目标岗位 | `/asu` |
+| 简历内容已确定，需要制作常规可编辑简历 | `/resume` |
+| 想复刻 ASu 同款高密度技术简历 | `/asu-resume` |
+| 已开始投递，需要整理招聘邮件和后续进度 | `/offer` |
+
+也可以组合多个入口：
+
+- **没有实习、想补充真实经历**：先用 `/contributor` 完成与岗位相关的开源贡献，再交给 `/asu` 整理成可核验的简历表述；
+- **已有项目、准备开始投递**：先用 `/asu` 对齐目标岗位，再用 `/resume` 或 `/asu-resume` 生成简历；
+- **已经投递、需要持续跟进**：直接用 `/offer` 整理邮件和状态，简历需要更新时再回到 `/asu` 和 `/resume`。
+
 ## 安装
 
 最简单的方式是把 GitHub 链接直接发给 Codex，并说明要安装插件：
@@ -258,4 +276,3 @@ asu-skills/
    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Hisn00w/ASu-skills&type=timeline&legend=top-left&sealed_token=bjbMfvRN5HhBif26VkNL7fMNZhYEU6NOxOMDWOzZvQnyJjYS5cPBNShexQ_xybTo30fuVzzhrKWq4x4IZAHEFrDesIwfK5iGJONtmrR_3Hhz3B2UFaKxs2iptYBKSxN0TbubpjnmkGaFme25ufww7AXpqptuXSHNK9KAWAP45t26kEa8NXXbLPxqH-5w" />
  </picture>
 </a>
-


### PR DESCRIPTION
> 本改动由 Risto0211 与 Codex 共同讨论和实现。

## 变更说明

在 README 的五个入口总览后增加“第一次使用：从哪个入口开始”章节，帮助新用户根据当前问题快速判断应先使用哪个 Skill。

同时补充三个组合使用场景，覆盖缺少真实经历、已有项目准备投递，以及已经投递需要持续跟进的情况。

## 变更类型

- [ ] `feat`：新增功能或资源
- [ ] `fix`：修复问题
- [x] `docs`：修改 README、贡献指南或其他文档
- [ ] `refactor`：重构目录或实现，不改变功能
- [ ] `chore`：构建、依赖或维护性修改
- [ ] `test`：新增或修改测试

## 关联问题

Closes #39

## 实现内容

- 主要改动：增加五个 Skill 的首次选择决策表和三个组合使用场景。
- 改动原因：现有 README 解释了每个入口的用途，但新用户仍需自行判断第一步应调用哪个 Skill。
- 影响范围：仅修改 `README.md`，不修改 Skill 行为、插件 manifest 或资源文件。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读根目录 [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已运行 `git diff --check`
- [x] 已检查修改内容中没有 `<<<<<<<`、`=======`、`>>>>>>>` 等冲突标记
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查
- [x] 若修改 HTML，已在浏览器中预览并检查编辑、保存、分页和导出效果
- [x] 若修改简历模板，已确认只修改用户专属副本，没有直接改动只读母版
- [x] 若新增图片或 Logo，已按仓库资源规范处理，没有使用低清截图或自行绘制品牌 Logo
- [x] 如存在合并冲突，已完成冲突处理并重新执行上述检查

## 验证结果

```text
git diff --check：通过
冲突标记检查：通过
改动文件范围检查：仅 README.md
JSON、Skill、HTML、简历模板和图片检查：本次未涉及
分支基于最新 upstream/main 创建，无合并冲突
```

## 额外说明

本次仅实现 issue #39 中的 README 文档方案，不新增第六个 Skill 或统一路由入口。