### PR TITLE
fix: 修复投递进度表本地日期偏移

### DIFF
--- a/assets/application-tracker.html
+++ b/assets/application-tracker.html
@@ -221,7 +221,12 @@
       let records = loadRecords();
       let editingId = null;
 
-      function today() { return new Date().toISOString().slice(0, 10); }
+      function today(date = new Date()) {
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const day = String(date.getDate()).padStart(2, '0');
+        return `${year}-${month}-${day}`;
+      }
       function makeId() {
         return window.crypto?.randomUUID ? window.crypto.randomUUID() : `record-${Date.now()}-${Math.random().toString(16).slice(2)}`;
       }


### PR DESCRIPTION
## 变更说明

修复投递进度表使用 UTC 日期导致的本地日期偏移。在非 UTC 时区的日期边界附近，新增记录日期、月度统计及备份文件名可能落到前一天或后一天。

## 变更类型

- [x] `fix`：修复问题

## 关联问题

无。

## 实现内容

- 主要改动：使用浏览器本地年、月、日生成 `YYYY-MM-DD`。
- 改动原因：`toISOString()` 返回 UTC 时间，不能用于本地日历日期。
- 影响范围：新增记录默认日期、本月投递统计、导入日期回退及 CSV/JSON 文件名。
- 保留 `updatedAt` 的 UTC ISO 时间戳，不改变绝对时间记录方式。

## 检查清单

- [x] 已阅读根目录 `AGENTS.md`
- [x] 已阅读根目录 `CONTRIBUTING.md`
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已运行 `git diff --check`
- [x] 已检查没有冲突标记、隐私、密钥或无关文件
- [x] 已完成相关 JavaScript 语法和跨时区回归检查
- [ ] 未完成自动浏览器预览，原因和替代验证见下方
- [x] 本次不涉及简历模板、图片或 Logo
- [x] 已确认可与开放 PR #31 无冲突合并

## 验证结果

```text
直接从 application-tracker.html 提取实际 today() 函数执行：

Asia/Shanghai 月初跨界：通过
Asia/Shanghai 闰日：通过
America/Los_Angeles 日期跨界：通过
UTC 基准：通过
完整内联 JavaScript 语法检查：通过
git diff --check：通过
与 PR #31 三方合并模拟：通过
```

自动浏览器因本地 `file://` 页面访问策略无法执行。此次未修改 HTML 结构或 CSS，使用实际函数跨时区执行和完整脚本语法检查作为替代验证。

## 额外说明

PR #31 中的 `updatedAt: new Date().toISOString()` 用于记录绝对更新时间，应继续保留 UTC 格式，本次不做修改。