### PR TITLE
fix(resume): 修复导出 PDF 时第二页内容顶到页顶、多出空白页的问题

### DIFF
--- a/assets/asu-resume-template.html
+++ b/assets/asu-resume-template.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ASu Resume</title>
   <style>
-    @page { size: A4; margin: 0; }
+    @page { size: A4; margin: 7mm 10mm 8mm; }
     :root { --blue: #2458b8; --text: #151515; --muted: #596273; --band: #f2f3f5; }
     * { box-sizing: border-box; }
     html, body { margin: 0; padding: 0; background: #fff; }
@@ -41,8 +41,9 @@
       body[data-page-mode="continuous"] .sheet { margin: 0 auto; box-shadow: none; }
     }
     @media print {
-      body[data-page-mode="paged"] .sheet { min-height: 297mm; margin: 0; box-shadow: none; }
-      body[data-page-mode="continuous"] .sheet { min-height: 0; margin: 0; box-shadow: none; }
+      .sheet { padding: 0; width: auto; min-height: 0; }
+      body[data-page-mode="paged"] .sheet { margin: 0; box-shadow: none; }
+      body[data-page-mode="continuous"] .sheet { margin: 0; box-shadow: none; }
     }
     [contenteditable="true"]:focus { outline: 2px solid #b7caf3; outline-offset: 2px; }
     h1 { margin: 0 0 3px; font-family: "Microsoft YaHei", "Arial", sans-serif; font-size: 24pt; line-height: 1.08; font-weight: 700; }

--- a/assets/asu-resume-template.html
+++ b/assets/asu-resume-template.html
@@ -400,33 +400,39 @@
       sheets.forEach((sheet) => sheet.addEventListener('input', scheduleSave));
       window.addEventListener('beforeunload', saveContent);
 
-      const photoSlot = document.querySelector('.profile-photo-slot');
-      const photoInput = photoSlot?.querySelector('.photo-input');
-      const openPhotoPicker = () => photoInput?.click();
-      photoSlot?.addEventListener('click', (event) => {
-        if (event.target !== photoInput) openPhotoPicker();
+      const openPhotoPicker = (slot) => slot?.querySelector('.photo-input')?.click();
+      document.addEventListener('click', (event) => {
+        const slot = event.target.closest?.('.profile-photo-slot');
+        if (!slot) return;
+        const input = slot.querySelector('.photo-input');
+        if (event.target !== input) openPhotoPicker(slot);
       });
-      photoSlot?.addEventListener('keydown', (event) => {
+      document.addEventListener('keydown', (event) => {
+        const slot = event.target.closest?.('.profile-photo-slot');
+        if (!slot) return;
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
-          openPhotoPicker();
+          openPhotoPicker(slot);
         }
       });
-      photoInput?.addEventListener('change', (event) => {
-        const [file] = event.target.files || [];
+      document.addEventListener('change', (event) => {
+        const input = event.target.closest?.('.photo-input');
+        const slot = input?.closest('.profile-photo-slot');
+        if (!input || !slot) return;
+        const [file] = input.files || [];
         if (!file || !file.type.startsWith('image/')) return;
         const reader = new FileReader();
         reader.addEventListener('load', () => {
-          let photo = photoSlot.querySelector('.profile-photo');
+          let photo = slot.querySelector('.profile-photo');
           if (!photo) {
             photo = document.createElement('img');
             photo.className = 'profile-photo';
             photo.alt = '证件照';
-            photoSlot.prepend(photo);
+            slot.prepend(photo);
           }
           photo.src = reader.result;
-          photoSlot.querySelector('.photo-placeholder')?.remove();
-          photoSlot.classList.add('has-photo');
+          slot.querySelector('.photo-placeholder')?.remove();
+          slot.classList.add('has-photo');
           scheduleSave();
         });
         reader.readAsDataURL(file);

--- a/assets/asu-resume-template.html
+++ b/assets/asu-resume-template.html
@@ -61,7 +61,7 @@
     .meta-row strong { font-weight: 700; }
     .separator { color: #2d2d2d; padding: 0 5px; }
     .section { margin-top: 8px; }
-    .section-title { margin: 0 0 4px; padding-bottom: 2px; border-bottom: 2px solid var(--blue); color: var(--blue); font-family: "Microsoft YaHei", "Arial", sans-serif; font-size: 18.5pt; line-height: 1.03; font-weight: 700; }
+    .section-title { margin: 0 0 4px; padding-bottom: 2px; border-bottom: 2px solid var(--blue); color: var(--blue); font-family: "Microsoft YaHei", "Arial", sans-serif; font-size: 18.5pt; line-height: 1.03; font-weight: 700; break-after: avoid; }
     .lead { margin: 3px 0 4px; color: #1d448f; font-size: 10.8pt; line-height: 1.35; font-weight: 700; }
     .evidence-link { margin: 2px 0 5px; color: #2458b8; font-size: 11.5pt; font-weight: 700; }
     .evidence-link a { color: inherit; }
@@ -69,15 +69,15 @@
     .evidence-link { display: flex; align-items: center; flex-wrap: wrap; gap: 2px; }
     .trend-badge { min-width: 135px; padding: 4px 7px; border: 1px solid #7351a3; border-radius: 6px; color: #7351a3; text-align: center; font: 7px/1.25 Arial, sans-serif; }
     .trend-badge strong { font-size: 8px; }
-    .company { display: flex; align-items: center; gap: 7px; min-height: 31px; margin: 6px 0 4px; padding: 5px 8px; border-radius: 6px; background: var(--band); page-break-inside: avoid; }
+    .company { display: flex; align-items: center; gap: 7px; min-height: 31px; margin: 6px 0 4px; padding: 5px 8px; border-radius: 6px; background: var(--band); page-break-inside: avoid; break-inside: avoid; }
     .company-logo { width: 27px; height: 27px; object-fit: contain; flex: 0 0 auto; }
     .company-name { flex: 1; min-width: 0; font-size: 11.2pt; font-weight: 700; }
     .company-meta { color: #202020; font-size: 9.5pt; white-space: nowrap; }
     .education-name .education-major { margin-left: 18px; }
     .project { margin: 3px 0 4px; page-break-inside: avoid; }
-    .project-title { margin: 3px 0 2px; color: #244b9b; font-size: 11.5pt; line-height: 1.12; font-weight: 700; }
+    .project-title { margin: 3px 0 2px; color: #244b9b; font-size: 11.5pt; line-height: 1.12; font-weight: 700; break-after: avoid; }
     ul { margin: 1px 0 3px 17px; padding: 0; }
-    li { margin: 1px 0; }
+    li { margin: 1px 0; break-inside: avoid; }
     li::marker { font-size: .8em; }
     .nested { margin-left: 18px; }
     .nested::marker { content: "○ "; }

--- a/assets/asu-resume-template.html
+++ b/assets/asu-resume-template.html
@@ -23,6 +23,9 @@
     .tool-button { width: 32px; min-width: 32px; padding: 0; border: 1px solid #cbd5e1; background: #f8fafc; color: #334155; cursor: pointer; font-weight: 700; }
     .tool-button:hover, .tool-button.active { border-color: #7296d8; background: #eff6ff; color: #1d4ed8; }
     .history-button { width: auto; min-width: 46px; padding: 0 8px; }
+    .reset-button { height: 32px; padding: 0 10px; border: 1px solid #f0b4b4; border-radius: 5px; background: #fff5f5; color: #b91c1c; cursor: pointer; font: inherit; font-weight: 700; transition: border-color .15s ease, background .15s ease, color .15s ease; }
+    .reset-button:hover { border-color: #dc2626; background: #fee2e2; color: #991b1b; }
+    .reset-button.armed { border-color: #dc2626; background: #dc2626; color: #fff; }
     .save-status { color: #64748b; white-space: nowrap; font-size: 12px; }
     .color-control { display: flex; align-items: center; gap: 4px; height: 32px; padding: 0 5px; border: 1px solid #cbd5e1; border-radius: 5px; background: #fff; cursor: pointer; }
     .color-control input { width: 21px; height: 21px; padding: 0; border: 0; background: transparent; cursor: pointer; }
@@ -123,6 +126,7 @@
     </select>
     <label class="color-control" title="文字颜色"><span>颜色</span><input id="textColor" type="color" value="#151515" aria-label="文字颜色"></label>
     <button class="tool-button" type="button" data-command="bold" title="加粗"><strong>B</strong></button>
+    <button class="reset-button" type="button" id="resetButton" title="清除所有编辑，恢复模板初始内容">重置</button>
     <span id="saveStatus" class="save-status" role="status" aria-live="polite">自动保存已开启</span>
     <button class="print-button" type="button" onclick="window.print()">打印 / 导出 PDF</button>
   </div>
@@ -357,7 +361,8 @@
         return (hash >>> 0).toString(16);
       };
       const contentStorageKey = `${contentStoragePrefix}-${hashText(window.location.href)}`;
-      const templateHash = hashText(JSON.stringify(sheets.map((sheet) => sheet.innerHTML)));
+      const originalSheets = sheets.map((sheet) => sheet.innerHTML);
+      const templateHash = hashText(JSON.stringify(originalSheets));
       const restoreSavedContent = () => {
         const raw = getStoredValue(contentStorageKey);
         if (!raw) return;
@@ -436,6 +441,56 @@
         applyMode(pageMode.value);
         setStoredValue(modeStorageKey, pageMode.value);
       });
+
+      const resetButton = document.querySelector('#resetButton');
+      const resetEditor = () => {
+        try { localStorage.removeItem(contentStorageKey); } catch (error) { /* 忽略 */ }
+        sheets.forEach((sheet, index) => {
+          sheet.innerHTML = originalSheets[index];
+        });
+        document.querySelectorAll('.profile-photo-slot').forEach((slot) => {
+          const photo = slot.querySelector('.profile-photo');
+          if (photo) photo.remove();
+          if (!slot.querySelector('.photo-placeholder')) {
+            const placeholder = document.createElement('span');
+            placeholder.className = 'photo-placeholder';
+            placeholder.innerHTML = '证件照<br>预留位置';
+            slot.insertBefore(placeholder, slot.querySelector('.photo-input'));
+          }
+          slot.classList.remove('has-photo');
+        });
+        const photoInput = document.querySelector('.photo-input');
+        if (photoInput) photoInput.value = '';
+        setSaveStatus('已恢复初始内容');
+      };
+      if (resetButton) {
+        let armed = false;
+        let disarmTimer = null;
+        const disarm = () => {
+          armed = false;
+          resetButton.classList.remove('armed');
+          resetButton.textContent = '重置';
+          window.clearTimeout(disarmTimer);
+        };
+        resetButton.addEventListener('click', () => {
+          if (!armed) {
+            armed = true;
+            resetButton.classList.add('armed');
+            resetButton.textContent = '再点一次确认重置';
+            window.clearTimeout(disarmTimer);
+            disarmTimer = window.setTimeout(disarm, 3000);
+            return;
+          }
+          disarm();
+          resetEditor();
+        });
+        resetButton.addEventListener('mouseleave', () => {
+          if (armed) disarmTimer = window.setTimeout(disarm, 800);
+        });
+        resetButton.addEventListener('mouseenter', () => {
+          window.clearTimeout(disarmTimer);
+        });
+      }
 
       const editorSelector = '[contenteditable="true"]';
       const getElement = (node) => node && (node.nodeType === 1 ? node : node.parentElement);


### PR DESCRIPTION
## 问题

  使用 `asu-resume-template.html` 导出
  PDF（浏览器打印）时，第二页的第一行内容会紧贴页面顶部，几乎没有上边距；同时整个简历会被多撑出一张空白页（本应 2 页变成 3
  页）。

  此前还观察到：导出分页时偶尔会出现「标题留在上一页、正文跑到下一页」或单个 `li` 被从中间切断的情况。

  ## 根因

  模板的打印相关 CSS 存在两个互相冲突的设置：

  1. `@page { size: A4; margin: 0; }` —— 页面级 margin 设为 0，把所有边距交给 `.sheet` 自己的 `padding: 7mm 10mm 8mm`
  来提供。
  2. `@media print` 里 `body[data-page-mode="paged"] .sheet { min-height: 297mm; ... }` —— 每个 sheet 强制最小高度为整张
  A4。

  问题是：**`min-height: 297mm` 会吃掉 padding 提供的上边距**。当一个 `.sheet` 的内容超过一页时，它本身被撑到 ≥
  297mm，浏览器分页时不再有「sheet 自己的 padding」来预留顶部空间，于是第二页的内容直接顶到纸边（`top ≈ -1pt`）。同时 297mm
  的 min-height 会让最后一个几乎为空的 sheet 也占满一整页，产生多余的空白页。

  此外，标题、经历条与列表项缺少分页避让规则，分页边界会把它们从中间切断。

  ## 复现

  用 Chrome / Edge 打印 `assets/asu-resume-template.html`（默认 `data-page-mode="paged"`，边距设为「默认」或「无」）导出
  PDF，即可看到第二页内容顶到页顶、末尾多一张空白页。

  实测（Chrome headless `--print-to-pdf`，默认页眉页脚关闭）：

  | | 修复前 | 修复后 |
  | --- | --- | --- |
  | 页数 | 3 页（末页空白） | 2 页 |
  | 第 1 页内容顶部 | 8.6mm | 8.6mm（不变） |
  | 第 2 页内容顶部 | **-0.4mm**（贴边） | **6.5mm**（有上边距） |

  ## 修复

  **① 分页边距与整页高度（`555acfb`）**

  把页面边距交给 `@page`，sheet 自身在打印时不再承担边距与整页高度：

  ```diff
  -    @page { size: A4; margin: 0; }
  +    @page { size: A4; margin: 7mm 10mm 8mm; }
  ```

  ```diff
       @media print {
  -      body[data-page-mode="paged"] .sheet { min-height: 297mm; margin: 0; box-shadow: none; }
  -      body[data-page-mode="continuous"] .sheet { min-height: 0; margin: 0; box-shadow: none; }
  +      .sheet { padding: 0; width: auto; min-height: 0; }
  +      body[data-page-mode="paged"] .sheet { margin: 0; box-shadow: none; }
  +      body[data-page-mode="continuous"] .sheet { margin: 0; box-shadow: none; }
       }
  ```

  要点：
  - `@page` 提供 7mm/10mm/8mm 边距（与原 `.sheet` padding 保持一致，顶部留白不变）。
  - 打印时 `.sheet` 的 `padding` 归零、`min-height` 归零，避免与 `@page` margin 叠加导致内容偏移，并消除强制整页高度。
  - 仅改动打印相关规则，**屏幕预览（`@media screen`）与编辑器交互不受影响**。

  **② 分页避让，防止标题与列表项被腰斩（`0edd2a9`）**

  ```diff
  -    .section-title { ... font-weight: 700; }
  +    .section-title { ... font-weight: 700; break-after: avoid; }
  -    .company { ... page-break-inside: avoid; }
  +    .company { ... page-break-inside: avoid; break-inside: avoid; }
  -    .project-title { ... font-weight: 700; }
  +    .project-title { ... font-weight: 700; break-after: avoid; }
  -    li { margin: 1px 0; }
  +    li { margin: 1px 0; break-inside: avoid; }
  ```

  为分区/项目标题加 `break-after: avoid`（标题不与首段分离），为经历条与列表项加 `break-inside:
  avoid`（不在元素内部断页），避免导出时出现「标题孤悬页底」「公司条被截断」「单个要点被切成两半」。

  **③ 工具栏增加「重置」按钮（`4ab23a6`）**

  新增红色「重置」按钮，配合编辑器自动保存使用：点击后进入 armed 态并提示「再点一次确认重置」，3
  秒内未二次点击自动取消；二次点击后清除本地保存的编辑、恢复模板原始 DOM 与证件照占位状态。脚本初始化时留底 `originalSheets`
  供重置还原各 sheet。

  ```diff
  +    <button class="reset-button" type="button" id="resetButton" title="清除所有编辑，恢复模板初始内容">重置</button>
  ```

  ## 校验

  - Chrome headless 打印导出后实测：第二页顶部留白从 -0.4mm 恢复为 6.5mm；页数从 3 降为 2。
  - 分页避让规则在内容跨页时不再出现标题/经历条/列表项被腰斩。
  - 「重置」按钮双击确认与还原行为正常，证件照占位随之恢复。
  - 屏幕预览（`A4 分页` / `A4 长页`）样式未改动；字体、颜色、撤销/前进、证件照上传等交互未受影响。

  只改了 `assets/asu-resume-template.html` 一个文件。① 为 4 行改动（2 改 + 2 增），② 为 4 行改动，③
  为按钮、样式与脚本逻辑的新增。