### PR TITLE
docs: 英文 README 补齐中文版已有的缺失章节与内容

### DIFF
--- a/README_en.md
+++ b/README_en.md
@@ -52,6 +52,7 @@ Pick your first entry based on the problem you most need to solve right now:
 | Have experience, but unsure how to match it to a target role | `/asu` |
 | Resume content is settled; need a regular editable resume | `/resume` |
 | Want to recreate the ASu-style high-density technical resume | `/asu-resume` |
+| Interviews coming up; want to predict questions and drill the weak spots | `/interview` |
 | Already applying; need to organize recruiting emails and follow-ups | `/offer` |
 
 You can also combine entries:

--- a/README_en.md
+++ b/README_en.md
@@ -42,7 +42,56 @@ ASu-skills is now a plugin pack. Installing it provides five individually callab
 | `/asu-resume`  | ASu-style resume         | Recreates the ASu single-column high-density technical resume, logo assets and PDF |
 | `/offer`       | Fall recruitment tracking | Tracks applications, assessments, interviews, offers, rejections, and recruiting emails |
 
+## First time: where to start
+
+Pick your first entry based on the problem you most need to solve right now:
+
+| Situation | Start with |
+| --------- | ---------- |
+| No verifiable projects or collaboration experience yet | `/contributor` |
+| Have experience, but unsure how to match it to a target role | `/asu` |
+| Resume content is settled; need a regular editable resume | `/resume` |
+| Want to recreate the ASu-style high-density technical resume | `/asu-resume` |
+| Already applying; need to organize recruiting emails and follow-ups | `/offer` |
+
+You can also combine entries:
+
+- **No internships, want real experience**: use `/contributor` to make role-relevant open-source contributions first, then hand them to `/asu` to turn into verifiable resume statements;
+- **Have projects, ready to apply**: use `/asu` to align with the target role first, then `/resume` or `/asu-resume` to generate the resume;
+- **Already applying, tracking ongoing progress**: use `/offer` directly to organize emails and statuses; come back to `/asu` and `/resume` whenever the resume needs an update.
+
 ## Installation
+
+ASu-skills works with both Codex and Claude Code: the repo root has `.codex-plugin/` for Codex and `.claude-plugin/` for Claude Code, sharing the same `skills/`, `assets/`, and `references/`.
+
+### Claude Code
+
+In a Claude Code session, run:
+
+```text
+/plugin marketplace add Hisn00w/ASu-skills
+/plugin install asu-skills@asu
+```
+
+You can also run the equivalent commands in a terminal:
+
+```bash
+claude plugin marketplace add Hisn00w/ASu-skills
+claude plugin install asu-skills@asu
+```
+
+If the install summary says `Run /reload-plugins to activate.`, run `/reload-plugins`; otherwise restart Claude Code. After installation, run `claude plugin details asu-skills` to confirm all six skills are loaded.
+
+Update and uninstall:
+
+```text
+/plugin marketplace update asu
+/plugin uninstall asu-skills
+```
+
+Uninstalling the plugin only removes the plugin cache; it never touches the application tracker you have edited in your project or user directory.
+
+### Codex
 
 The easiest way is to send the GitHub link directly to Codex and ask it to install the plugin:
 
@@ -62,6 +111,18 @@ $resume Turn my experience into an editable Chinese HTML resume.(Considering may
 $asu-resume Recreate the single-column high-density technical resume from the reference image and output an editable HTML.
 $offer Turn these recruiting emails into a fall recruitment application tracker.
 ```
+
+## Local validation
+
+After modifying SKILL.md, `agents/openai.yaml`, `.codex-plugin/plugin.json`, or adding a new skill, run the static validator to confirm that frontmatter, metadata, and resource references are valid:
+
+```bash
+python3 scripts/validate_skills.py
+```
+
+The validator checks: that each SKILL.md exists; that its frontmatter parses; that `name` matches the directory name; that `description` is non-empty and not too long; that `agents/openai.yaml` parses; that local references/assets paths cited in SKILL.md exist; and that `.codex-plugin/plugin.json` is valid JSON pointing to resources that actually exist. GitHub Actions runs this validator automatically on PRs that touch `skills/**` and related paths.
+
+Routing regression cases live in `tests/skill-routing-cases.yaml`, recording the expected routing for each job-search entry, as input for future Agent Evals.
 
 ## `/contributor`: Make real open-source contributions
 
@@ -116,6 +177,7 @@ Supported:
 - 18 Chinese HTML templates;(ask ur agent for a English ver if u like :)
 - A4 single- or two-page layout;
 - In-browser editing of text, photo, fonts, colors, and bold;
+- “Local fonts” reads fonts installed on your system (Chrome 103+, requires browser permission); “Import fonts” loads local font files (TTF/OTF/WOFF/WOFF2) as a supplement;
 - Print-to-PDF export;
 - Layout analysis from screenshots: columns, spacing, font size, colors, and pagination;
 - Fictional placeholder photos by default; swap in your own for the real resume.
@@ -144,7 +206,8 @@ The template includes:
 - Phone, email, WeChat, identity, education, and Star icons under `assets/icons/`;
 - OpenAI, Claude, ByteDance, bilibili, and GitHub SVG logos under `assets/logos/`;
 - Continuous A4 two-page layout with in-browser editing and PDF export;
-- An HTML toolbar that toggles between `A4 paginated` and `A4 long-page (unlimited height)`; the paginated mode shows paper shadow, while the long-page mode keeps A4 width and centers the content.
+- An HTML toolbar that toggles between `A4 paginated` and `A4 long-page (unlimited height)`; the paginated mode shows paper shadow, while the long-page mode keeps A4 width and centers the content;
+- The toolbar's “Local fonts” option reads fonts installed on your system (Chrome 103+, requires browser permission), and “Import fonts” loads local font files (TTF/OTF/WOFF/WOFF2) as a supplement; select text and apply a font from the “Local fonts” group. Imported fonts last for the current session only and must be re-imported after a refresh.
 
 Typical usage:
 
@@ -155,6 +218,18 @@ Read the resume I provide, recreate the same single-column high-density technica
 ```
 
 When adding new AI, model, platform, or company logos, follow the [LobeHub Icons skill guide](https://lobehub.com/icons/skill.md) and use the SVG/CDN assets from `@lobehub/icons` or `@lobehub/icons-static-svg` — never low-res screenshots or hand-drawn brand icons.
+
+## `/interview`: Stress-test your resume
+
+`/interview` extracts the claims that need verification from your resume and target role, predicts high-probability interview questions, and — asking exactly one question at a time — drills you with follow-up questions to check whether you can clearly explain your individual responsibilities, technical implementation, metric definitions, decision trade-offs, and failure stories. The review flags high-risk wording, knowledge gaps, and resume claims that need more evidence or a softer tone; it never fabricates interview answers for you.
+
+Typical usage:
+
+```text
+/interview grill
+
+Here is my resume; my target role is AI Application Engineer. Start from the highest-risk project and ask me one question at a time; if my answer is vague, keep drilling.
+```
 
 ## `/offer`: Fall recruitment progress management
 
@@ -195,6 +270,10 @@ Recommended order:
 
 You can also state a combined goal in a single request, e.g.: “first use `/contributor` to gather the merged PRs, then `/asu` to rewrite the experience, and finally `/resume` to generate an HTML resume”.
 
+When combining multiple entries, when your materials conflict, or when a resume contains strong claims, you can copy [`assets/career-claim-ledger-template.json`](assets/career-claim-ledger-template.json) to set up a claim–evidence ledger. It lets open-source contributions, experience rewrites, and resume files share the same facts, confirmation statuses, and personal boundaries; see [`skills/asu/references/claim-evidence-ledger.md`](skills/asu/references/claim-evidence-ledger.md) for the detailed rules.
+
+To see how one person's materials flow through the entries, read the [end-to-end fictional job-search case](docs/end-to-end-fictional-case.md). Starting from course projects and an open-source contribution, it walks through the evidence card, the experience rewrite, the editable resume, and the application tracker, clearly distinguishing completed, in-progress, and to-be-filled items.
+
 ## Truthfulness boundaries
 
 ASu-skills' “Sulishing” means strong positioning, strong evidence, and clear expression — never fabricated experience. Please keep to these rules:
@@ -211,8 +290,15 @@ ASu-skills' “Sulishing” means strong positioning, strong evidence, and clear
 
 ```text
 asu-skills/
+├── .claude-plugin/
+│   ├── plugin.json              # Claude Code plugin manifest
+│   └── marketplace.json         # Claude Code plugin marketplace manifest
 ├── .codex-plugin/
 │   └── plugin.json              # Plugin manifest
+├── package.json                 # DSH plugin pack manifest (bundle patch entry)
+├── cordis.patch.yml             # Registers the DSH filesystem skill provider
+├── lib/
+│   └── index.js                 # DSH plugin entry module
 ├── skills/
 │   ├── asu/
 │   │   ├── SKILL.md             # /asu experience Sulishing
@@ -226,6 +312,9 @@ asu-skills/
 │   ├── asu-resume/
 │   │   ├── SKILL.md             # /asu-resume ASu-style technical resume
 │   │   ├── references/          # Template structure & layout rules
+│   │   └── agents/openai.yaml
+│   ├── interview/
+│   │   ├── SKILL.md             # /interview interview prediction & follow-up drilling
 │   │   └── agents/openai.yaml
 │   └── offer/
 │       ├── SKILL.md             # /offer fall recruitment tracking


### PR DESCRIPTION
## 变更说明

英文 README 是在 `/interview` skill（#42）加入之前翻译的（#38），此后一直未与中文版同步。本 PR 将中文 README 已有而英文版缺失的章节与内容补齐为忠实翻译，不改变任何中文文档和 skill 文件。

## 变更类型

- [x] `docs`：修改 README、贡献指南或其他文档

## 关联问题

无（#61 额外说明中预告的文档同步工作）

## 实现内容

- 主要改动（均针对 `README_en.md`，对照中文 README 逐段翻译）：
  - 新增「First time: where to start」章节（对应「第一次使用：从哪个入口开始」）；
  - Installation 章节补齐双平台说明与「Claude Code」小节（marketplace 安装、更新、卸载），原 Codex 内容归入「Codex」小节；
  - 新增「Local validation」章节（对应「本地校验」，含 `validate_skills.py` 与路由回归用例说明）；
  - 新增 `/interview`: Stress-test your resume 完整章节（对应「把简历问穿」，含典型用法）；
  - 「How the entries work together」章节补上主张—证据账本与端到端虚构案例两段（对应中文版同位置内容）；
  - `/resume` 与 `/asu-resume` 功能列表补上「本地字体 / 导入字体」条目（#56 新增功能当时未同步到英文版）；
  - File structure 树补齐 `.claude-plugin/`、`package.json`、`cordis.patch.yml`、`lib/`、`interview/` 等中文版已有条目；
  - 「First time」表格补充 `/interview` 场景行（追加提交），中文侧对应行见 #64。
- 改动原因：英文 README 缺失章节导致英文读者看不到 `/interview` 的存在、Claude Code 安装方式和本地校验流程，功能列表也与实际不符。
- 影响范围：仅 `README_en.md` 一个文件，不涉及 skill、模板和代码。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读根目录 [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已运行 `git diff --check`
- [x] 已检查修改内容中没有 `<<<<<<<`、`=======`、`>>>>>>>` 等冲突标记
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的自动化检查（本次未改动 skill/JSON，仍运行了校验器确认无回归）
- [ ] 若修改 HTML，已在浏览器中预览（本次未修改 HTML）
- [ ] 若修改简历模板（本次未修改）
- [ ] 若新增图片或 Logo（本次未新增）
- [x] 如存在合并冲突（与 #61 的改动区域不重叠，如 #61 先合并会自动处理）

## 验证结果

```text
$ git diff --check
（无输出，退出码 0）

$ python scripts/validate_skills.py
skills validation: 43/43 checks passed

新增章节引用的文件均确认存在：
assets/career-claim-ledger-template.json / skills/asu/references/claim-evidence-ledger.md
docs/end-to-end-fictional-case.md / tests/skill-routing-cases.yaml / scripts/validate_skills.py

章节结构与中文 README 对齐：
First time → Installation(Claude Code/Codex) → Local validation → /contributor → /asu
→ /resume → /asu-resume → /interview → /offer → entries together → Truthfulness → File structure
```

Markdown 已在本地预览确认渲染正常，表格、代码块和引用路径格式正确。

## 额外说明

- 本 PR 与 #61（skill 数量修正）改动区域不重叠，可按任意顺序合并；文中「six skills」表述以两 PR 全部合并后的终态为准。
- 翻译时保留了两处原有英文版的本地化差异（如 HR 开场白平台的 LinkedIn/Line 表述），未回改为中文版的 Boss 直聘/微信。
- 「First time」表格的 `/interview` 行：中文版表格原本没有该行，为保持中英一致，英文侧行随本 PR 先行补齐，中文侧对应改动见 #64。
