### PR TITLE
test: 路由用例补全 contributor、interview、offer 三个零覆盖入口

### DIFF
--- a/tests/skill-routing-cases.yaml
+++ b/tests/skill-routing-cases.yaml
@@ -46,3 +46,39 @@ cases:
   - prompt: "按照阿酥模板复刻并输出 HTML"
     expected: asu-resume
     note: 明确复刻模板 + 生成 HTML，命中 /asu-resume。
+
+  - prompt: "帮我在 GitHub 上找一个容易合并的开源仓库，先做一个小 PR"
+    expected: contributor
+    note: 典型 first contribution 请求，命中 /contributor。
+
+  - prompt: "目标岗位是后端开发，帮我扫一些开源项目的 typo 和坏链接机会，展示改动方案后我再确认"
+    expected: contributor
+    note: 展示候选 + 用户确认后提交 PR 的核心流程，命中 /contributor。
+
+  - prompt: "帮我找几个能写进简历的开源小活"
+    expected: contributor
+    note: 边界 case：同时提到「开源小活」与「写进简历」，contributor 的 description 明确包含「把 PR 写进简历」，归 /contributor 而非 /asu。
+
+  - prompt: "根据我的简历和目标岗位，预测面试官大概率会问什么问题"
+    expected: interview
+    note: 面试预测请求，命中 /interview。
+
+  - prompt: "模拟一场压力面，一次只问一个问题，我答得含糊就继续追问"
+    expected: interview
+    note: 模拟面试 / 压力面 + 连续追问，命中 /interview。
+
+  - prompt: "帮我检查简历上的项目经历我自己能不能讲清楚，讲不透的地方标出来"
+    expected: interview
+    note: 边界 case：涉及简历内容，但动作是检查掌握程度而非制作简历文件，归 /interview 而非 /resume。
+
+  - prompt: "把我投递过的公司和当前状态整理成一张求职进度表"
+    expected: offer
+    note: 典型秋招进度管理请求，命中 /offer。
+
+  - prompt: "这封招聘邮件是说我进入面试了吗？帮我判断证据并更新状态"
+    expected: offer
+    note: 招聘邮件状态判断，证据不足时标待确认，命中 /offer。
+
+  - prompt: "简历已经定稿开始投递了，帮我记录每家公司的进展和下一步"
+    expected: offer
+    note: 边界 case：提到简历定稿，但动作是记录投递进展，归 /offer 而非 /resume。


### PR DESCRIPTION
## 变更说明

`tests/skill-routing-cases.yaml` 现有 6 条 case 只覆盖 asu（3）、resume（1）、asu-resume（2），contributor、interview、offer 三个入口完全没有用例。本 PR 为这三个入口各补 3 条（含 1 条边界 case），使六个入口在路由回归数据集中均有覆盖。

## 变更类型

- [x] `test`：新增或修改测试

## 关联问题

无

## 实现内容

- 主要改动：新增 9 条 case——
  - contributor ×3：first contribution 请求、展示候选+确认后提 PR 流程、边界 case（「找能写进简历的开源小活」，contributor description 明确包含「把 PR 写进简历」，与 /asu 区分）；
  - interview ×3：面试预测、模拟压力面+连续追问、边界 case（「检查简历上的经历能否讲清楚」，动作是检查掌握程度而非制作简历，与 /resume 区分）；
  - offer ×3：投递进度表、招聘邮件状态判断（证据不足标待确认）、边界 case（「简历定稿开始投递，记录进展」，与 /resume 区分）。
- 改动原因：三个入口零用例，description 的路由区分度无法回归；文件头注释明确欢迎边界 case 用于压测路由区分度。
- 影响范围：仅 `tests/skill-routing-cases.yaml`，不改变现有 6 条 case。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读根目录 [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已运行 `git diff --check`
- [x] 已检查修改内容中没有冲突标记
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的自动化检查（YAML 解析 + schema 校验，见验证结果）
- [ ] 若修改 HTML，已在浏览器中预览（本次未修改 HTML）
- [ ] 若修改简历模板（本次未修改）
- [ ] 若新增图片或 Logo（本次未新增）
- [x] 如存在合并冲突（基于最新 main，无冲突）

## 验证结果

```text
$ python -c "import yaml; ..."
total cases: 15
Counter({'asu': 3, 'contributor': 3, 'interview': 3, 'offer': 3, 'asu-resume': 2, 'resume': 1})
schema OK（每条含 prompt/expected，expected 均为 skills/ 下存在的目录名）

$ git diff --check
（无输出，退出码 0）

$ python scripts/validate_skills.py
skills validation: 43/43 checks passed
```

## 额外说明

resume 目前只有 1 条 case，本 PR 未顺手扩充以保持「一个 PR 只改一件事」；如维护者需要，可后续单独补充 resume 的边界 case。
