### PR TITLE
docs: 在 README 添加贡献者头像墙

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,14 @@ asu-skills/
 
 感谢 [LobeHub/lobe-icons](https://github.com/lobehub/lobe-icons) 提供开源品牌图标资源；本插件按其技能说明优先使用 `@lobehub/icons` 及静态 SVG/CDN 资源。
 
+## Contributors
+
+感谢所有为 ASu-skills 做出贡献的人。
+
+<a href="https://github.com/Hisn00w/ASu-skills/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Hisn00w/ASu-skills" alt="Contributors" />
+</a>
+
 ## 开源协议
 
 本项目基于 [MIT License](LICENSE) 发布，可自由使用、修改与分发，欢迎 fork 与 PR。开源治理体系由社区 Owner 主导建设，已实现全链路 License 覆盖率 100%。

--- a/README_en.md
+++ b/README_en.md
@@ -350,6 +350,14 @@ This plugin has organized, structured, and compliance-adjusted the relevant cont
 
 Thanks to [LobeHub/lobe-icons](https://github.com/lobehub/lobe-icons) for the open-source brand icon resources; following its skill guide, this plugin prefers `@lobehub/icons` and static SVG/CDN assets.
 
+## Contributors
+
+Thanks to everyone who contributes to ASu-skills.
+
+<a href="https://github.com/Hisn00w/ASu-skills/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Hisn00w/ASu-skills" alt="Contributors" />
+</a>
+
 ## License
 
 This project is released under the [MIT License](LICENSE). Free to use, modify, and distribute; forks and PRs are welcome. The open-source governance is led by community Owners, with 100% license coverage across the entire pipeline.


### PR DESCRIPTION
## 变更说明

为 README 添加 GitHub Contributors 贡献者头像墙，展示项目贡献者并增强社区参与感。

## 变更类型

- [x] `docs`：修改 README、贡献指南或其他文档

## 关联问题

无

## 实现内容

- 主要改动：在 `README.md` 和 `README_en.md` 添加 Contributors 区域。
- 改动原因：展示项目贡献者，感谢参与开源协作的用户。
- 影响范围：仅影响 README 文档展示，不改变项目功能。

## 检查清单

- [x] 已阅读根目录 `AGENTS.md`
- [x] 已阅读 `.github/CONTRIBUTING.md`
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已运行 `git diff --check`
- [x] 已检查修改内容中没有冲突标记

## 验证结果

```text
已运行：
git diff --check

已检查 README Markdown 结构和 Contributors 图片链接。