### PR TITLE
feat: 新增 TraeWork 插件打包与安装支持

### DIFF
--- a/.trae-plugin/plugin.json
+++ b/.trae-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "asu-skills",
+  "version": "0.3.0",
+  "description": "中文求职工作流：开源贡献、经历酥化、同款技术简历制作、面试准备和秋招进度管理。",
+  "author": {
+    "name": "Hisn0w",
+    "url": "https://github.com/Hisn00w"
+  },
+  "homepage": "https://github.com/Hisn00w/ASu-skills",
+  "repository": "https://github.com/Hisn00w/ASu-skills",
+  "license": "MIT",
+  "keywords": ["resume", "interview", "job-search", "career", "open-source", "contributor", "chinese", "asu"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "ASu-skills",
+    "shortDescription": "用 /contributor、/asu、/resume、/asu-resume、/interview、/offer 完成中文求职工作流",
+    "longDescription": "ASu-skills 将开源贡献、经历酥化、中文简历制作、同款高密度技术简历复刻、面试准备和秋招进度管理拆成六个可单独调用的 TraeWork skill，挂在同一个 asu-skills 插件下。",
+    "developerName": "Hisn0w",
+    "category": "Productivity",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "websiteURL": "https://github.com/Hisn00w/ASu-skills",
+    "defaultPrompt": [
+      "用 /contributor 寻找与目标岗位匹配的开源贡献机会。",
+      "用 /asu 酥化我的经历并生成 HR 开场白。",
+      "用 /resume 制作可编辑 HTML 简历。",
+      "用 /asu-resume 根据参考图复刻同款单栏高密度技术简历。",
+      "用 /interview 根据简历预测面试问题并通过连续追问检查掌握程度。",
+      "用 /offer 记录我的秋招投递和进度。"
+    ],
+    "brandColor": "#11A683",
+    "composerIcon": "./assets/asu-circle.png",
+    "logo": "./assets/asu-circle.png"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ ASu-skills 现在是一个插件包。安装后会提供六个可单独调用的
 
 ## 安装
 
-ASu-skills 同时支持 Codex 和 Claude Code：仓库根目录的 `.codex-plugin/` 供 Codex 使用，`.claude-plugin/` 供 Claude Code 使用，两者共用同一套 `skills/`、`assets/` 和 `references/`。
+ASu-skills 同时支持 Codex、Claude Code 和 TraeWork：仓库根目录的 `.codex-plugin/` 供 Codex 使用，`.claude-plugin/` 供 Claude Code 使用，`.trae-plugin/` 供 TraeWork 使用，三者共用同一套 `skills/`、`assets/` 和 `references/`。
 
 ### Claude Code
 
@@ -113,6 +113,16 @@ $asu-resume 根据我的经历复刻参考图中的单栏高密度技术简历�
 $interview 根据我的简历预测面试问题，并通过连续追问检查我是否真的掌握这些经历。
 $offer 把这些招聘邮件整理成秋招投递进度表。
 ```
+
+### TraeWork
+
+TraeWork 通过 `.trae-plugin/plugin.json` 清单把仓库打包成插件，六个 skill 会以 `<publisher>:asu-skills:<skill>` 的形式挂在该插件下。
+
+1. 把本仓库整体复制到 TraeWork 插件目录：`~/.trae-cn/plugins/<publisher>/asu-skills/<version>/`，保留 `.trae-plugin/plugin.json`、`skills/`、`assets/` 和 `references/`；
+2. 重启 TraeWork，让新插件被重新加载；
+3. 新建对话，在输入框输入 `/`，从命令列表选择 `contributor`、`asu`、`resume`、`asu-resume`、`interview` 或 `offer`。
+
+其中 `<publisher>` 是插件目录下的命名空间，可自行指定（如 `local`），`<version>` 为 `plugin.json` 中的版本号。卸载时删除对应插件目录即可，不会影响你在项目或用户目录里编辑过的求职进度表。
 
 ## 本地校验
 
@@ -295,6 +305,8 @@ asu-skills/
 │   └── marketplace.json         # Claude Code 插件市场清单
 ├── .codex-plugin/
 │   └── plugin.json              # 插件清单
+├── .trae-plugin/
+│   └── plugin.json              # TraeWork 插件清单
 ├── package.json                # DSH 插件包清单（bundle patch 入口）
 ├── cordis.patch.yml            # 注册 DSH filesystem skill 提供方
 ├── lib/

--- a/README_en.md
+++ b/README_en.md
@@ -64,7 +64,7 @@ You can also combine entries:
 
 ## Installation
 
-ASu-skills works with both Codex and Claude Code: the repo root has `.codex-plugin/` for Codex and `.claude-plugin/` for Claude Code, sharing the same `skills/`, `assets/`, and `references/`.
+ASu-skills works with Codex, Claude Code, and TraeWork: the repo root has `.codex-plugin/` for Codex, `.claude-plugin/` for Claude Code, and `.trae-plugin/` for TraeWork, all sharing the same `skills/`, `assets/`, and `references/`.
 
 ### Claude Code
 
@@ -114,6 +114,16 @@ $asu-resume Recreate the single-column high-density technical resume from the re
 $interview Predict likely interview questions from my resume and drill me with one follow-up question at a time to check whether I really master these experiences.
 $offer Turn these recruiting emails into a fall recruitment application tracker.
 ```
+
+### TraeWork
+
+TraeWork packages this repository as a plugin via the `.trae-plugin/plugin.json` manifest, and the six skills become available under the plugin as `<publisher>:asu-skills:<skill>`.
+
+1. Copy this repository into the TraeWork plugin directory: `~/.trae-cn/plugins/<publisher>/asu-skills/<version>/`, keeping `.trae-plugin/plugin.json`, `skills/`, `assets/`, and `references/`;
+2. Restart TraeWork so the new plugin is reloaded;
+3. Start a new conversation, type `/` in the input box, and pick `contributor`, `asu`, `resume`, `asu-resume`, `interview`, or `offer` from the command list.
+
+`<publisher>` is a namespace you choose under the plugin directory (for example `local`), and `<version>` is the version in `plugin.json`. To uninstall, delete the plugin directory; it never touches the application tracker you have edited in your project or user directory.
 
 ## Local validation
 
@@ -299,6 +309,8 @@ asu-skills/
 │   └── marketplace.json         # Claude Code plugin marketplace manifest
 ├── .codex-plugin/
 │   └── plugin.json              # Plugin manifest
+├── .trae-plugin/
+│   └── plugin.json              # TraeWork plugin manifest
 ├── package.json                 # DSH plugin pack manifest (bundle patch entry)
 ├── cordis.patch.yml             # Registers the DSH filesystem skill provider
 ├── lib/


### PR DESCRIPTION
feat: 新增 TraeWork 插件打包与安装支持

## 变更说明

为 ASu-skills 新增 TraeWork 打包与安装支持：仓库根目录新增 `.trae-plugin/plugin.json` 插件清单，六个 skill 会以 `<publisher>:asu-skills:<skill>` 的形式挂在该插件下；中英文 README 的安装章节补充了 TraeWork 安装步骤，文件结构中补上 `.trae-plugin/`。

该改动让 ASu-skills 也能在 TraeWork 中作为插件整体加载，正是仓库欢迎的「让六个 skill 在别的 agent 环境里也能加载」。

## 变更类型

- [x] `feat`：新增功能或资源（新增 TraeWork 插件清单）
- [ ] `fix`：修复问题
- [x] `docs`：修改 README、贡献指南或其他文档（补充 TraeWork 安装说明）
- [ ] `refactor`：重构目录或实现，不改变功能
- [ ] `chore`：构建、依赖或维护性修改
- [ ] `test`：新增或修改测试

## 关联问题

无

## 实现内容

- 主要改动：新增 `.trae-plugin/plugin.json`；README.md 与 README_en.md 安装章节新增 `### TraeWork`，文件结构加入 `.trae-plugin/`。
- 改动原因：仓库目前只覆盖 Codex 和 Claude Code 的安装路径，缺 TraeWork；本改动补上，且不触碰任何 skill 源文件。
- 影响范围：仅新增插件清单与文档；不动 `skills/**`、`assets/`、首页功能，现有 Codex / Claude Code 安装不受影响。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息（`feat:`、`docs:` + 中文标题）
- [x] 已运行 `git diff --check`
- [x] 已检查修改内容中没有 `<<<<<<<`、`=======`、`>>>>>>>` 等冲突标记
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查
- [x] 若修改 HTML，已在浏览器中预览并检查编辑、保存、分页和导出效果（本次不涉及 HTML，不适用）
- [x] 若修改简历模板，已确认只修改用户专属副本，没有直接改动只读母版（本次不涉及简历模板，不适用）
- [x] 若新增图片或 Logo，已按仓库资源规范处理（本次未新增图片/Logo，仅复用已有 `assets/asu-circle.png`，不适用）
- [x] 如存在合并冲突，已完成冲突处理并重新执行上述检查（无冲突）

## 验证结果

```text
.trae-plugin/plugin.json 已用 ConvertFrom-Json 解析通过
  - skills 指向 ./skills/（six 个 SKILL.md 均存在）
  - composerIcon / logo 指向 ./assets/asu-circle.png，资源存在
git diff --check  通过（无空白错误）
未修改 skills/** 与 .codex-plugin/，因此不触发仓库 validate_skills.py 的 CI 校验路径
```

## 额外说明

无