### PR TITLE
asu-resume: copy official SVG logos to user resume and prefer @lobehub/icons when shared asset missing

### DIFF
--- a/skills/asu-resume/SKILL.md
+++ b/skills/asu-resume/SKILL.md
@@ -18,13 +18,13 @@ description: 中文同款技术简历制作技能：基于 ASu 单栏高密度�
 0. 将“我要阿酥同款简历”视为调用 `/asu-resume`；先复制只读模板，再在副本中填入用户资料和经历，保留模板文件不变。
 1. 读取用户提供的简历、PDF、截图、项目材料或主张—证据账本，提取真实姓名、联系方式、教育、经历、项目、技能和公开链接；使用账本时遵循 [状态与交接规则](../asu/references/claim-evidence-ledger.md)，最终 PDF 只使用“已确认”主张。
 2. 先把经历改写成“目标身份 → 项目全景 → 个人职责 → 技术动作 → 结果证据”，再排版；不把截图直接嵌入简历。
-3. 根据公司/平台名称选择共享 Logo 资源 `../../assets/logos/`。当前可用 `openai.svg`、`claude.svg`、`bytedance-color.svg`、`bilibili-color.svg` 和 `github.svg`；找不到时使用文字条，不要臆造 Logo。
+3. 为每段能够确认公司或平台名称的经历匹配品牌 Logo。优先复用共享资源 `../../assets/logos/`；共享目录没有对应品牌时，从 `@lobehub/icons` 或 `@lobehub/icons-static-svg` 获取官方 SVG。把实际使用的 SVG 复制到用户专属简历旁的 `logos/` 目录，并让 HTML 使用 `logos/<brand>.svg` 相对路径，避免生成后因仓库路径或网络不可用而丢失。只有品牌无法确认或 LobeHub 没有可用资源时才保留纯文字公司条，不要臆造或用相似品牌 Logo 代替。
 4. 生成真正可编辑的 HTML；个人信息区的通用图标从 `../../assets/icons/` 读取，保留可点击上传或替换的证件照预留位。模板工具栏提供两种页面模式：`A4 分页` 用于常规打印分页，`A4 长页（不限高度）` 用于单页连续编辑；同一工具栏支持选中文字后修改字体、字号、颜色和加粗，提供撤回/前进，并将编辑内容自动保存到浏览器本地；同时支持打印或导出 PDF。
 5. 单页优先把“身份定位—最强证据—核心经历—技能”排成完整闭环；需要双页时先填实第一页，再把补充经历放到第二页。最后按 `/resume` 的 [A4 页面平衡与视觉密度 QA](../resume/references/page-balance-qa.md) 检查页面占用、中文字体、长文本溢出、公开链接在打印件中是否可识别、Logo 比例和跨页衔接。
 
 ## 图标规则
 
-生成 AI、模型、平台或公司图标时，优先遵循 [LobeHub Icons 技能说明](https://lobehub.com/icons/skill.md)，使用 `@lobehub/icons` 或 `@lobehub/icons-static-svg` 的 SVG/CDN 资源。不要手绘已有品牌图标，也不要用低清截图替代可缩放资源。新增 Logo 时登记到 [references/asu-resume-template.md](references/asu-resume-template.md) 的 Logo 表。
+生成 AI、模型、平台或公司图标时，优先遵循 [LobeHub Icons 技能说明](https://lobehub.com/icons/skill.md)，使用 `@lobehub/icons` 或 `@lobehub/icons-static-svg` 的 SVG 资源。不要手绘已有品牌图标，也不要用低清截图替代可缩放资源。用户专属 Logo 只需随用户副本保存；只有将可复用 Logo 新增到仓库共享资源时，才登记到 [references/asu-resume-template.md](references/asu-resume-template.md) 的 Logo 表。
 
 电话、邮箱、微信、身份、教育和 Star 等通用图标也使用下载的 SVG，不使用 Emoji。用户后续可将证件照放入模板右上角的预留框中。
 

--- a/skills/asu-resume/references/asu-resume-template.md
+++ b/skills/asu-resume/references/asu-resume-template.md
@@ -40,7 +40,9 @@ Logo 文件统一放在 `../../assets/logos/`，文件名使用小写英文或�
 | 哔哩哔哩        | `../../assets/logos/bilibili-color.svg`  | 哔哩哔哩、B站、Bilibili           |
 | GitHub          | `../../assets/logos/github.svg`          | GitHub、Github、开源仓库          |
 
-新增公司时，优先从 `@lobehub/icons` 的组件或静态 SVG/CDN 获取资源，命名为 `../../assets/logos/<brand>.svg`，再在本表登记别名。素材缺失时显示文字，不要用相似公司的 Logo 代替。
+生成用户专属简历时，每段能够确认品牌的公司或平台经历都应显示 Logo：先复用上表中的共享资源；缺少对应品牌时，从 `@lobehub/icons` 或 `@lobehub/icons-static-svg` 获取官方 SVG，并复制到用户 HTML 同级的 `logos/<brand>.svg`，由 HTML 通过相对路径引用。这样用户移动、预览或导出简历时不依赖仓库目录和网络。只有品牌无法确认或 LobeHub 没有可用资源时才显示纯文字公司条，不要用相似公司的 Logo 代替。
+
+只有需要把新 Logo 沉淀为仓库共享资源时，才将文件命名为 `../../assets/logos/<brand>.svg` 并在本表登记别名；用户专属 Logo 不回写只读母版或共享资源目录。
 
 ## 内容规则
 


### PR DESCRIPTION
### Motivation

- Ensure logos referenced by generated ASu resumes remain available offline and don't break when the repository path or network is unavailable. 
- Prefer authoritative SVG sources (`@lobehub/icons` / `@lobehub/icons-static-svg`) when a shared logo is not present to avoid low-quality or improvised graphics. 
- Keep the read-only template and shared assets immutable while allowing per-user resume copies to include required logos.

### Description

- Updated `SKILL.md` to require that when a company/platform is confirmed, the generator first reuses `../../assets/logos/` and otherwise fetches the official SVG from `@lobehub/icons` or `@lobehub/icons-static-svg` and copies it into a `logos/` directory next to the generated user HTML. 
- Changed the HTML usage guidance to reference copied logos via a relative path `logos/<brand>.svg` so exported/previews do not depend on repo paths or network access. 
- Clarified that only logos intentionally added to repository shared assets should be named under `../../assets/logos/<brand>.svg` and recorded in the template reference; user-specific logos must not be written back to the read-only template. 
- Adjusted `references/asu-resume-template.md` to reflect the new logo resource flow and reiterated priority of `@lobehub/icons` SVG resources and the rule not to substitute or fabricate brand logos.

### Testing

- No automated tests were run for these documentation and workflow changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c684b20048332ac66f96f8e36eb82)