### PR TITLE
fix: 处理技能提供方加载失败

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,8 @@ export function apply(ctx, config = {}) {
     }).then((id) => {
       if (disposed) ctx.loader.remove(id);
       else entryId = id;
+    }).catch((error) => {
+      console.error(`Failed to load ${PROVIDER} for ${name}.`, error);
     });
     return () => {
       disposed = true;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
+    "test": "node --test",
     "export:pdf": "node scripts/export-resume-pdf.mjs",
     "build:templates": "node scripts/inline-template.mjs --all dist/templates"
   },

--- a/tests/lib-index.test.js
+++ b/tests/lib-index.test.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { apply } from '../lib/index.js';
+
+test('reports rejected loader creation promises', async () => {
+  const errors = [];
+  const originalError = console.error;
+  let cleanup;
+
+  console.error = (...args) => errors.push(args);
+  try {
+    const ctx = {
+      effect(effect) {
+        cleanup = effect();
+      },
+      loader: {
+        create: async () => {
+          throw new Error('loader unavailable');
+        },
+        remove() {},
+      },
+    };
+
+    apply(ctx);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(errors.length, 1);
+    assert.match(errors[0][0], /Failed to load @deepseek-ai\/dsh-skill-filesystem for asu-skills/);
+    assert.equal(errors[0][1].message, 'loader unavailable');
+  } finally {
+    cleanup?.();
+    console.error = originalError;
+  }
+});


### PR DESCRIPTION
## 变更说明

为 `ctx.loader.create()` 增加 rejection handling，避免热安装技能提供方失败时产生未处理的 Promise rejection，并将错误记录到 stderr 便于诊断；同时补充聚焦回归测试和 `npm test` 脚本。

## 变更类型

- [ ] `feat`：新增功能或资源
- [x] `fix`：修复问题
- [ ] `docs`：修改 README、贡献指南或其他文档
- [ ] `refactor`：重构目录或实现，不改变功能
- [ ] `chore`：构建、依赖或维护性修改
- [x] `test`：新增或修改测试

## 关联问题

无（独立的错误处理修复提案）。

## 实现内容

- 主要改动：在 `lib/index.js` 的 loader 创建 Promise 链末尾增加 `.catch()`，记录提供方名称和原始错误。
- 改动原因：loader 创建失败时原实现只有成功处理分支，拒绝会成为未处理 Promise rejection，且缺少可诊断日志。
- 影响范围：仅影响 loader 创建失败时的错误处理；成功加载、卸载和已销毁实例的清理逻辑保持不变。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已运行 `git diff --check`
- [x] 已检查修改内容中没有 `<<<<<<<`、`=======`、`>>>>>>>` 等冲突标记
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查
- [x] 若修改 HTML，已在浏览器中预览并检查编辑、保存、分页和导出效果
- [x] 若修改简历模板，已确认只修改用户专属副本，没有直接改动只读母版
- [x] 若新增图片或 Logo，已按仓库资源规范处理，没有使用低清截图或自行绘制品牌 Logo
- [x] 如存在合并冲突，已完成冲突处理并重新执行上述检查

## 验证结果

```text
- npm test：通过（1 个测试）
- node --check lib/index.js：通过
- python -m json.tool package.json：通过
- npm run build:templates：通过，未产生额外工作区改动
- npm pack --dry-run --json：通过，包内容包含 lib/index.js 和 package.json
- git diff --check：通过
```

## 额外说明

无。
