### PR TITLE
fix: 修复简历模板长标题溢出

### DIFF
--- a/assets/templates-html/frame/base.css
+++ b/assets/templates-html/frame/base.css
@@ -47,8 +47,9 @@ body { margin:0; padding:76px 18px 42px !important; color:var(--ink); font-famil
 .variant-blue-line .section-title { font-weight:800; }
 .variant-blue-line .resume-section:first-of-type { margin-top:16px; }
 .variant-blue-line .resume-header { border-bottom:4px solid var(--rule); }
-.variant-band .section-title { padding:6px 12px; color:#fff; background:linear-gradient(90deg,var(--blue) 0 118px,#edf0f3 118px); border-bottom:0; }
-.variant-band .section-title span:first-child { min-width:95px; }
+.variant-band .section-title { gap:0; padding:0; color:#fff; background:#edf0f3; border-bottom:0; }
+.variant-band .section-title > span:first-child { min-width:95px; padding:6px 12px; background:var(--blue); }
+.variant-band .section-title > .section-en { padding:6px 0 6px 12px; }
 .variant-band .resume-section { margin-top:18px; }
 .variant-english .section-title { text-transform:none; letter-spacing:.01em; }
 .variant-english .section-title span:first-child::after { content:" /"; color:#a9b1bc; }
@@ -58,8 +59,9 @@ body { margin:0; padding:76px 18px 42px !important; color:var(--ink); font-famil
 .variant-black .section-title { color:#14171a; border-bottom:3px solid #14171a; }
 .variant-black .section-title::before { content:""; width:8px; height:22px; background:#14171a; display:inline-block; margin-right:1px; }
 .variant-ribbon .identity h1 { color:var(--blue); }
-.variant-ribbon .section-title { padding:6px 12px; color:#fff; border:0; background:linear-gradient(90deg,#315f98 0 145px,#eff1f3 145px); }
-.variant-ribbon .section-title span:first-child { min-width:120px; }
+.variant-ribbon .section-title { gap:0; padding:0; color:#fff; border:0; background:#eff1f3; }
+.variant-ribbon .section-title > span:first-child { min-width:120px; padding:6px 12px; background:#315f98; }
+.variant-ribbon .section-title > .section-en { padding:6px 0 6px 12px; }
 .variant-ribbon .entry-head { grid-template-columns:135px minmax(0,1fr) minmax(100px,auto); }
 .variant-compact { font-size:13px; }
 .variant-compact .resume-page { padding:38px 48px 50px; }
@@ -125,6 +127,8 @@ body { margin:0; padding:76px 18px 42px !important; color:var(--ink); font-famil
 .variant-modern .resume-header { border-bottom:12px solid #e8eef4; }
 .variant-modern .section-title { color:#1e6792; border-bottom:1px solid #77a8c2; }
 .variant-modern .section-title::before { content:"01"; color:#77a8c2; font-size:12px; letter-spacing:.08em; }
+.variant-band.variant-modern .section-title { color:#fff; }
+.variant-band.variant-modern .section-title::before { align-self:stretch; display:flex; align-items:center; padding:6px 0 6px 12px; background:var(--blue); }
 .variant-academic .resume-page { border-top:16px solid #17191b; }
 .variant-academic .section-title { letter-spacing:.04em; }
 .variant-academic .section-en { color:#17191b; }


### PR DESCRIPTION
## 变更说明

修复简历模板长标题超出蓝色标题标签的问题，并恢复模板 15 的蓝底白字对比度。

## 变更类型

- [ ] feat：新增功能或资源
- [x] fix：修复问题
- [ ] docs：修改 README、贡献指南或其他文档
- [ ] refactor：重构目录或实现，不改变功能
- [ ] chore：构建、依赖或维护性修改
- [ ] test：新增或修改测试

## 关联问题

Closes #82

## 实现内容

- 主要改动：将固定宽度的标题背景改为随标题内容自适应，并修复 variant-modern 的文字对比度。
- 改动原因：长标题会越过蓝色区域，模板 15 的标题文字在蓝底上可读性不足。
- 影响范围：variant-band、variant-ribbon 及共享对应样式的模板；未修改简历内容。

## 检查清单

- [x] 已阅读根目录 AGENTS.md
- [x] 已阅读 .github/CONTRIBUTING.md
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已运行 git diff --check
- [x] 已检查修改内容中没有冲突标记
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径（本次未修改）
- [x] 已完成相关技能校验和模板构建检查
- [x] 已在浏览器中预览，并检查模板显示与 A4 PDF 导出效果
- [x] 已确认未修改只读简历母版（本次未涉及）
- [x] 已确认未新增图片或 Logo
- [x] 已确认无合并冲突

## 验证结果

python scripts/validate_skills.py：47/47 checks passed
node scripts/inline-template.mjs --all：18 套模板内联成功
Chrome 浏览器预览：通过
PDF 导出、A4 和中文文本抽查：通过
git diff --check：通过

## 额外说明

无。