### PR TITLE
fix: 校验 agents/openai.yaml 内容

### DIFF
--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -11,7 +11,8 @@
   3. frontmatter 的 name 与所在目录名一致；
   4. description 非空、长度合理（<= 500 字符，避免 description 过长导致
      命令菜单截断或路由混乱）；
-  5. agents/openai.yaml 存在且可解析为合法 YAML（最小子集：key: value）；
+  5. agents/openai.yaml 存在且可解析为合法 YAML，并包含可用的
+     interface.display_name、interface.short_description、interface.default_prompt；
   6. SKILL.md 中引用的本地 references / assets 路径实际存在
      （仅检查相对路径，跳过 http(s)/mailto/锚点）；
   7. .codex-plugin/plugin.json 是合法 JSON，且 interface.capabilities、
@@ -130,13 +131,60 @@ def parse_frontmatter(text: str) -> Tuple[dict, str]:
 # 极简 agents/openai.yaml 解析
 # --------------------------------------------------------------------------- #
 #
-# openai.yaml 同样只用了 `key: value` 形式（参见仓库内现有 5 个文件）。
-# 复用 frontmatter 解析器即可覆盖；若文件使用更复杂结构，会以解析失败处理。
-# --------------------------------------------------------------------------- #
+# openai.yaml supports the top-level keys and one nested mapping used by the
+# OpenAI skill metadata schema. A small parser keeps validation dependency-free;
+# unsupported YAML constructs fail deterministically instead of being ignored.
+
 
 
 def parse_simple_yaml(text: str) -> Tuple[dict, str]:
-    return parse_frontmatter("---\n" + text + "\n---\n")
+    """解析 openai.yaml 使用的顶层键和一层嵌套映射。"""
+    data: dict = {}
+    nested_key = None
+    nested_indent = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if ":" not in line:
+            return {}, f"YAML 行无法解析为 key: value：{line!r}"
+        key, _, value = line.strip().partition(":")
+        key = key.strip()
+        value = _strip_quotes(value)
+        if not key:
+            return {}, f"YAML 行缺少 key：{line!r}"
+
+        if indent == 0:
+            if key in data:
+                return {}, f"YAML 重复键：{key!r}"
+            if value:
+                data[key] = value
+                nested_key = None
+                nested_indent = None
+            else:
+                data[key] = {}
+                nested_key = key
+                nested_indent = None
+            continue
+
+        if nested_key is None:
+            return {}, f"YAML 存在没有顶层父键的嵌套键：{key!r}"
+        if nested_indent is None:
+            nested_indent = indent
+        elif indent != nested_indent:
+            return {}, "YAML 仅支持一层嵌套映射"
+        if not value:
+            return {}, f"YAML 不支持更深层嵌套或空值：{key!r}"
+        nested = data[nested_key]
+        if not isinstance(nested, dict):
+            return {}, f"YAML 父键不是映射：{nested_key!r}"
+        if key in nested:
+            return {}, f"YAML 重复键：{nested_key}.{key}"
+        nested[key] = value
+
+    return data, ""
 
 
 # --------------------------------------------------------------------------- #
@@ -159,6 +207,40 @@ def resolve_local_link(skill_dir: Path, target: str) -> Path:
     """
     target = target.split("#", 1)[0]
     return (skill_dir / target).resolve()
+
+
+def check_openai_interface(skill_dir: Path, skill_name: str, manifest: dict, report: Report) -> None:
+    """校验 agents/openai.yaml 的 interface 元数据。
+
+    OpenAI skill 元数据使用一层 interface 映射；即使 YAML 语法有效，
+    缺失这些字段也会导致宿主无法展示或路由 skill。
+    """
+    interface = manifest.get("interface")
+    if not isinstance(interface, dict):
+        report.add(False, skill_name, "agents/openai.yaml 缺少 interface 对象")
+        return
+    report.add(True, skill_name, "agents/openai.yaml interface 为对象")
+
+    required_fields = ("display_name", "short_description", "default_prompt")
+    for field_name in required_fields:
+        value = interface.get(field_name)
+        if isinstance(value, str) and value.strip():
+            report.add(True, skill_name, f"agents/openai.yaml interface.{field_name} 非空")
+        else:
+            report.add(False, skill_name, f"agents/openai.yaml interface.{field_name} 缺失或为空")
+
+    for field_name in ("icon_small", "icon_large"):
+        value = interface.get(field_name)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not value.strip():
+            report.add(False, skill_name, f"agents/openai.yaml interface.{field_name} 必须是非空字符串")
+            continue
+        resolved = (skill_dir / value).resolve()
+        if resolved.is_file():
+            report.add(True, skill_name, f"agents/openai.yaml interface.{field_name} 指向存在的资源（{value}）")
+        else:
+            report.add(False, skill_name, f"agents/openai.yaml interface.{field_name} 指向不存在的资源：{value}")
 
 
 def check_skill(skill_dir: Path, report: Report) -> None:
@@ -221,6 +303,7 @@ def check_skill(skill_dir: Path, report: Report) -> None:
                 report.add(False, skill_name, "agents/openai.yaml 为空或无有效键")
             else:
                 report.add(True, skill_name, "agents/openai.yaml 可解析")
+                check_openai_interface(skill_dir, skill_name, parsed, report)
         except UnicodeDecodeError as exc:
             report.add(False, skill_name, f"agents/openai.yaml 非 UTF-8 编码：{exc}")
 

--- a/tests/test_validate_skills.py
+++ b/tests/test_validate_skills.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""validate_skills.py 的聚焦回归测试。"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.validate_skills import Report, check_openai_interface, parse_simple_yaml
+
+
+class ParseSimpleYamlTests(unittest.TestCase):
+    def test_parses_interface_mapping(self):
+        parsed, error = parse_simple_yaml(
+            'interface:\n'
+            '  display_name: "Example"\n'
+            '  short_description: "A skill"\n'
+            '  default_prompt: "Run the skill"\n'
+        )
+
+        self.assertEqual(error, "")
+        self.assertEqual(parsed["interface"]["display_name"], "Example")
+        self.assertEqual(parsed["interface"]["default_prompt"], "Run the skill")
+
+    def test_rejects_nested_mapping_without_parent(self):
+        parsed, error = parse_simple_yaml("  display_name: Example\n")
+
+        self.assertEqual(parsed, {})
+        self.assertIn("没有顶层父键", error)
+
+
+class OpenAIInterfaceTests(unittest.TestCase):
+    def setUp(self):
+        self.skill_dir = Path(tempfile.mkdtemp())
+
+    def _messages(self, manifest):
+        report = Report()
+        check_openai_interface(self.skill_dir, "example", manifest, report)
+        return report.results
+
+    def test_requires_interface_and_display_metadata(self):
+        results = self._messages({})
+
+        self.assertFalse(all(result.ok for result in results))
+        self.assertIn("缺少 interface 对象", results[0].message)
+
+    def test_requires_all_routing_fields(self):
+        results = self._messages({"interface": {"display_name": "Example"}})
+
+        failures = [result.message for result in results if not result.ok]
+        self.assertTrue(any("short_description" in message for message in failures))
+        self.assertTrue(any("default_prompt" in message for message in failures))
+
+    def test_valid_metadata_passes(self):
+        results = self._messages(
+            {
+                "interface": {
+                    "display_name": "Example",
+                    "short_description": "A skill",
+                    "default_prompt": "Run the skill",
+                }
+            }
+        )
+
+        self.assertTrue(all(result.ok for result in results))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明

补充 `scripts/validate_skills.py` 对 `skills/*/agents/openai.yaml` 的内容校验。此前校验器只确认 YAML 可解析，缺失或空的 `interface` 元数据仍可能通过检查；本 PR 增加结构、路由字段和可选图标资源校验，并提供聚焦回归测试。

## 变更类型

- [ ] `feat`：新增功能或资源
- [x] `fix`：修复问题
- [ ] `docs`：修改 README、贡献指南或其他文档
- [ ] `refactor`：重构目录或实现，不改变功能
- [ ] `chore`：构建、依赖或维护性修改
- [x] `test`：新增或修改测试
- [ ] `ci`：修改 CI/CD 流程或自动化检查

## 关联问题

无（维护性校验覆盖增强）。

## 实现内容

- 主要改动：支持解析 `openai.yaml` 的一层 `interface` 映射；校验 `interface`、`display_name`、`short_description` 和 `default_prompt`；校验可选 `icon_small`/`icon_large` 的本地资源路径。
- 改动原因：仅通过 YAML 语法校验无法发现宿主展示或路由所需元数据缺失的问题。
- 影响范围：仅影响静态校验器及其测试，不改变现有有效 skill 元数据。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查
- [x] 若修改 HTML，已在浏览器中预览并检查编辑、保存、分页和导出效果（本次未修改 HTML）
- [x] 若修改简历模板，已确认只修改用户专属副本，没有直接改动只读母版（本次未修改简历模板）
- [x] 若新增图片或 Logo，已按资源规范处理（本次未新增图片或 Logo）
- [x] 若提交历史中存在 `merge/revert` 操作，确认修改内容中无未处理的冲突标记
- [x] 若与最新主分支存在合并冲突，已保留双方有效内容并解决所有冲突

## 验证结果

```text
python -m unittest discover -s tests -p 'test_validate_skills.py' -v  -> 5 tests passed
python scripts/validate_skills.py                                  -> 83/83 checks passed
git diff --check                                                -> passed
python -m py_compile scripts/validate_skills.py                  -> passed
```

## 额外说明

无。
