### PR TITLE
docs: 修复 Harness 工程仓库链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ASu 正在建设一套面向求职场景的 Harness 工程，欢迎通过 Issue 
 
 <img src="assets/harness-update.png" alt="ASu Harness 工程更新" width="560" />
 
-[前往 GitHub 查看 ASu Harness 工程](https://github.com/Hisn00w/Asu)
+[前往 GitHub 查看 ASu Harness 工程](https://github.com/Hisn00w/ASu-skills)
 
 ASu-skills 现在是一个插件包。安装后会提供七个可单独调用的入口：
 

--- a/README_en.md
+++ b/README_en.md
@@ -48,7 +48,7 @@ ASu is building a Harness project tailored to the job-search journey. We welcome
 
 <img src="assets/harness-update.png" alt="ASu Harness project update" width="560" />
 
-[Check out the ASu Harness project on GitHub](https://github.com/Hisn00w/Asu)
+[Check out the ASu Harness project on GitHub](https://github.com/Hisn00w/ASu-skills)
 
 ASu-skills is now a plugin pack. Installing it provides seven individually callable entry points:
 


### PR DESCRIPTION
## 变更说明

修复中英文 README 的 Harness 工程链接，将其从 `Hisn00w/Asu` 更正为 `Hisn00w/ASu-skills`，与仓库自身徽章、插件元数据和安装文档保持一致。

## 变更类型

- [ ] `feat`：新增功能或资源
- [x] `fix`：修复问题
- [ ] `docs`：修改 README、贡献指南或其他文档
- [ ] `refactor`：重构目录或实现，不改变功能
- [ ] `chore`：构建、依赖或维护性修改
- [ ] `test`：新增或修改测试
- [ ] `ci`：修改 CI/CD 流程或自动化检查

## 关联问题

无。本 PR 修复启发式复核发现的 README 链接错误。

## 实现内容

- 主要改动：更新 `README.md` 和 `README_en.md` 中 Harness 工程的 GitHub URL。
- 改动原因：两个 README 将 Harness 工程错误指向 `Hisn00w/Asu`，与仓库当前内容和元数据所指向的 `Hisn00w/ASu-skills` 不一致。
- 影响范围：仅文档链接，不改变运行时代码、插件元数据或资源。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查（本次仅修改 Markdown 链接，无相关 JSON/技能文件变更）
- [x] 若修改 HTML，已在浏览器中预览并检查编辑、保存、分页和导出效果（本次未修改 HTML）
- [x] 若修改简历模板，已确认只修改用户专属副本，没有直接改动只读母版（本次未修改简历模板）
- [x] 若新增图片或 Logo，已按仓库资源规范处理，没有使用低清截图或自行绘制品牌 Logo（本次未新增图片或 Logo）
- [x] 若提交历史中存在 `merge/revert` 操作，确认修改内容中无未处理的冲突标记（本次提交历史无相关操作，且已检查）
- [x] 若与最新主分支存在合并冲突，已保留双方有效内容并解决所有冲突，随后重新执行本清单中的检查（分支基于最新 `upstream/main`，无冲突）

## 验证结果

```text
git diff --check：通过
README 链接回归检查：通过；README.md 与 README_en.md 均包含 https://github.com/Hisn00w/ASu-skills，且不再包含旧的 https://github.com/Hisn00w/Asu
变更范围检查：通过；相对 upstream/main 仅修改 README.md 和 README_en.md，各 1 行链接
```

## 额外说明

无
