### PR TITLE
docs: avoid hardcoded resume logo inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ python3 scripts/validate_skills.py
 - 顶部最右侧预留证件照位置，个人信息区使用 SVG 图标，不使用 Emoji；
 - 蓝色分区标题、浅灰公司条和高密度项目要点；
 - `assets/icons/` 中的电话、邮箱、微信、身份、教育和 Star 图标；
-- `assets/logos/` 中的 OpenAI、Claude、ByteDance、bilibili、GitHub SVG Logo；
+- `assets/logos/` 中按实际目录维护的品牌 SVG Logo；
 - A4 两页连续排版、浏览器编辑和 PDF 导出。
 - HTML 工具栏可切换 `A4 分页` 或 `A4 长页（不限高度）`，分页模式带纸张阴影，长页模式保持 A4 宽度并居中。
 - 工具栏「本地字体」可读取系统中已安装的字体（Chrome 103+，需浏览器授权），「导入字体」可读取本地字体文件（TTF/OTF/WOFF/WOFF2）作为补充，选中文字后从「本地字体」分组应用；导入的字体仅本次会话有效，刷新后需重新导入。

--- a/README_en.md
+++ b/README_en.md
@@ -239,7 +239,7 @@ The template includes:
 - A reserved photo slot in the top-right; the personal info section uses SVG icons, no emoji;
 - Blue section headings, light-gray company bars, and dense project bullets;
 - Phone, email, WeChat, identity, education, and Star icons under `assets/icons/`;
-- OpenAI, Claude, ByteDance, bilibili, and GitHub SVG logos under `assets/logos/`;
+- Brand SVG logos maintained by the actual contents of `assets/logos/`;
 - Continuous A4 two-page layout with in-browser editing and PDF export;
 - An HTML toolbar that toggles between `A4 paginated` and `A4 long-page (unlimited height)`; the paginated mode shows paper shadow, while the long-page mode keeps A4 width and centers the content;
 - The toolbar's “Local fonts” option reads fonts installed on your system (Chrome 103+, requires browser permission), and “Import fonts” loads local font files (TTF/OTF/WOFF/WOFF2) as a supplement; select text and apply a font from the “Local fonts” group. Imported fonts last for the current session only and must be re-imported after a refresh.

--- a/skills/asu-resume/references/asu-resume-template.md
+++ b/skills/asu-resume/references/asu-resume-template.md
@@ -28,21 +28,13 @@
 - 证件照：右上角预留框支持点击选择本地图片，已有照片时再次点击即可替换。
 - 页面密度：按 [`/make-resume` 页面平衡规则](../../make-resume/references/page-balance-qa.md) 测量每张 `.sheet`；优先通过内容重排和结构合并消除大面积空白，不靠缩小到难读或添加装饰填充。
 
-## Logo 资源库
+## Logo 资源
 
-Logo 文件统一放在 `../../assets/logos/`，文件名使用小写英文或品牌英文名，和简历内容解耦。获取 AI、模型、平台或公司 Logo 时，优先遵循 [LobeHub Icons 技能说明](https://lobehub.com/icons/skill.md)，使用 `@lobehub/icons` 或 `@lobehub/icons-static-svg` 的 SVG/CDN 资源。
+共享 Logo 统一放在 `../../assets/logos/`，文件名使用小写英文或品牌英文名，并与简历内容解耦。这里不维护固定的品牌清单：生成简历时应以该目录中实际存在的 SVG 文件为准，避免文档列出的文件名与共享资源发生漂移。获取 AI、模型、平台或公司 Logo 时，优先遵循 [LobeHub Icons 技能说明](https://lobehub.com/icons/skill.md)，使用 `@lobehub/icons` 或 `@lobehub/icons-static-svg` 的 SVG/CDN 资源。
 
-| 简历名称        | 文件                                       | 匹配别名                          |
-| --------------- | ------------------------------------------ | --------------------------------- |
-| OpenAI          | `../../assets/logos/openai.svg`           | OpenAI、GPT、OpenAI API           |
-| Claude          | `../../assets/logos/claude.svg`           | Claude、Anthropic、Claude API     |
-| 抖音 / 字节跳动 | `../../assets/logos/bytedance-color.svg` | 抖音、字节跳动、ByteDance、TikTok |
-| 哔哩哔哩        | `../../assets/logos/bilibili-color.svg`  | 哔哩哔哩、B站、Bilibili           |
-| GitHub          | `../../assets/logos/github.svg`          | GitHub、Github、开源仓库          |
+生成用户专属简历时，先检查共享目录中的实际文件，并仅为能够确认的品牌匹配 Logo；目录中没有对应资源时，从 `@lobehub/icons` 或 `@lobehub/icons-static-svg` 获取官方 SVG，并复制到用户 HTML 同级的 `logos/<brand>.svg`，由 HTML 通过相对路径引用。这样用户移动、预览或导出简历时不依赖仓库目录和网络。只有品牌无法确认或 LobeHub 没有可用资源时才显示纯文字公司条，不要用相似公司的 Logo 代替。
 
-生成用户专属简历时，每段能够确认品牌的公司或平台经历都应显示 Logo：先复用上表中的共享资源；缺少对应品牌时，从 `@lobehub/icons` 或 `@lobehub/icons-static-svg` 获取官方 SVG，并复制到用户 HTML 同级的 `logos/<brand>.svg`，由 HTML 通过相对路径引用。这样用户移动、预览或导出简历时不依赖仓库目录和网络。只有品牌无法确认或 LobeHub 没有可用资源时才显示纯文字公司条，不要用相似公司的 Logo 代替。
-
-只有需要把新 Logo 沉淀为仓库共享资源时，才将文件命名为 `../../assets/logos/<brand>.svg` 并在本表登记别名；用户专属 Logo 不回写只读母版或共享资源目录。
+只有需要把新 Logo 沉淀为仓库共享资源时，才将文件命名为 `../../assets/logos/<brand>.svg`；用户专属 Logo 不回写只读母版或共享资源目录。
 
 ## 内容规则
 

--- a/tests/test_validate_skill_routing.py
+++ b/tests/test_validate_skill_routing.py
@@ -28,7 +28,7 @@ class ValidateSkillRoutingTests(unittest.TestCase):
             REPO_ROOT / "skills",
         )
 
-        self.assertEqual(case_count, 15)
+        self.assertEqual(case_count, 18)
         self.assertEqual(errors, [])
 
     def test_accepts_bom_and_quoted_colon(self):


### PR DESCRIPTION
## 变更说明

`skills/asu-resume/references/asu-resume-template.md` 维护了一个固定的品牌 Logo 表，但共享 `assets/logos/` 会随资源演进而变化，文档清单容易漂移并误导简历生成流程。本 PR 改为以共享目录中的实际 SVG 文件为准，并同步 README 中的描述。

## 变更类型

- [ ] `feat`：新增功能或资源
- [ ] `fix`：修复问题
- [x] `docs`：修改 README、贡献指南或其他文档
- [ ] `refactor`：重构目录或实现，不改变功能
- [ ] `chore`：构建、依赖或维护性修改
- [ ] `test`：新增或修改测试
- [ ] `ci`：修改 CI/CD 流程或自动化检查

## 关联问题

无。

## 实现内容

- 移除 `asu-resume` 参考文档中的硬编码品牌清单与别名表。
- 明确生成简历时检查 `assets/logos/` 的实际 SVG 内容，仅为已确认品牌匹配 Logo。
- 保留缺失品牌从 LobeHub Icons 获取官方 SVG 并复制到用户副本的规则。
- 同步中英文 README，改为描述实际目录维护的品牌 Logo。
- 影响范围：`asu-resume` Logo 资源说明及 README 模板能力描述；不修改模板 HTML 或共享 Logo 文件。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查
- [x] 若修改 HTML，已在浏览器中预览并检查编辑、保存、分页和导出效果（不适用，未修改 HTML）
- [x] 若修改简历模板，已确认只修改用户专属副本，没有直接改动只读母版（不适用，未修改 HTML 模板）
- [x] 若新增图片或 Logo，已按资源规范处理（不适用，未新增图片或 Logo）
- [x] 若提交历史中存在 `merge/revert` 操作，确认修改内容中无未处理的冲突标记（本分支无 merge/revert 操作）
- [x] 若与最新主分支存在合并冲突，已保留双方有效内容并解决所有冲突，随后重新执行本清单中的检查（当前分支基于最新 main，无冲突）

## 验证结果

```text
python scripts/validate_skills.py
→ skills validation: 47/47 checks passed

git diff --check
→ passed

Manual review:
→ verified the five current files under assets/logos/ are the only shared SVG logo resources; no HTML template or logo asset was modified.
```

## 额外说明

无。
