### PR TITLE
fix: 修复 OpenCode 指定目录安装与 Windows 输出兼容性

### DIFF
--- a/.opencode-plugin/install-opencode.py
+++ b/.opencode-plugin/install-opencode.py
@@ -3,11 +3,25 @@
 ASu-skills OpenCode 安装脚本
 自动将 skills/ 目录复制到 OpenCode 的 skills 目录
 """
+import argparse
 import os
-import sys
-import shutil
 import platform
+import shutil
 from pathlib import Path
+
+
+SKILL_NAMES = (
+    "contributor",
+    "asu-recap",
+    "project-guide",
+    "asu",
+    "make-resume",
+    "asu-resume",
+    "job-apply",
+    "interview",
+    "offer",
+)
+
 
 def find_opencode_skills_dir():
     """查找 OpenCode skills 目录"""
@@ -53,60 +67,79 @@ def find_opencode_skills_dir():
 
     return None
 
+
 def install_skills(skills_dir, source_dir):
     """将 skills 复制到目标目录"""
     source = Path(source_dir)
     target = Path(skills_dir)
 
-    if not source.exists():
-        print(f"❌ 源目录不存在: {source}")
+    if not source.is_dir():
+        print(f"[ERROR] 源目录不存在: {source}")
         return False
 
-    print(f"📦 安装 ASu-skills 到: {target}")
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        print(f"[ERROR] 无法创建 OpenCode skills 目录: {target} ({exc})")
+        return False
 
-    # 要安装的 skills
-    skill_names = ["contributor", "asu-recap", "project-guide", "asu", "make-resume", "asu-resume", "job-apply", "interview", "offer"]
+    print(f"[INFO] 安装 ASu-skills 到: {target}")
 
-    for skill_name in skill_names:
+    for skill_name in SKILL_NAMES:
         src = source / skill_name
         dst = target / skill_name
 
-        if not src.exists():
-            print(f"   ⚠️  跳过 {skill_name}（源目录不存在）")
+        if not src.is_dir():
+            print(f"[WARN] 跳过 {skill_name}（源目录不存在）")
             continue
 
         if dst.exists():
-            # 检查是否已安装
-            print(f"   ⚠️  {skill_name} 已存在，覆盖安装")
+            print(f"[WARN] {skill_name} 已存在，覆盖安装")
 
-        # 复制
-        if dst.exists():
-            shutil.rmtree(dst)
-        shutil.copytree(src, dst)
-        print(f"   ✅ {skill_name}")
+        try:
+            if dst.exists():
+                shutil.rmtree(dst)
+            shutil.copytree(src, dst)
+        except OSError as exc:
+            print(f"[ERROR] 安装 {skill_name} 失败: {exc}")
+            return False
+        print(f"[OK] {skill_name}")
 
     print()
-    print("✅ 安装完成！请重启 OpenCode 或执行 /reload-plugins")
+    print("[OK] 安装完成！请重启 OpenCode 或执行 /reload-plugins")
     print("   使用触发词：/contributor  /asu-recap  /project-guide  /asu  /make-resume  /asu-resume  /job-apply  /interview  /offer")
     return True
 
-def main():
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="将 ASu-skills 安装到 OpenCode skills 目录。",
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        help="显式指定 OpenCode skills 目录；未提供时自动查找。",
+    )
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
     script_dir = Path(__file__).parent
     source_dir = script_dir.parent / "skills"
 
-    # 查找 OpenCode skills 目录
-    skills_dir = find_opencode_skills_dir()
+    if args.target is not None:
+        skills_dir = args.target.expanduser()
+    else:
+        skills_dir = find_opencode_skills_dir()
 
     if not skills_dir:
-        print("❌ 未找到 OpenCode skills 目录")
+        print("[ERROR] 未找到 OpenCode skills 目录")
         print("   请手动指定目录：python install-opencode.py --target /path/to/skills")
-        sys.exit(1)
+        return 1
 
-    # 检查是否指定了目标目录
-    if len(sys.argv) > 2 and sys.argv[1] == "--target":
-        skills_dir = Path(sys.argv[2])
+    return 0 if install_skills(skills_dir, source_dir) else 1
 
-    install_skills(skills_dir, source_dir)
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/.opencode-plugin/installation-guide.md
+++ b/.opencode-plugin/installation-guide.md
@@ -11,6 +11,18 @@ cd ASu-skills
 python .opencode-plugin/install-opencode.py
 ```
 
+如果 OpenCode 使用自定义 skills 目录，或自动查找失败，可以显式指定安装位置：
+
+```bash
+# Windows
+python .opencode-plugin/install-opencode.py --target "D:\OpenCode\skills"
+
+# macOS / Linux
+python .opencode-plugin/install-opencode.py --target /custom/opencode/skills
+```
+
+`--target` 优先于自动查找；指定目录不存在时，安装脚本会自动创建。路径中包含空格时请使用引号。
+
 ## 方法 2：手动安装
 
 ```bash

--- a/tests/test_opencode_installer.py
+++ b/tests/test_opencode_installer.py
@@ -1,0 +1,101 @@
+import contextlib
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / ".opencode-plugin" / "install-opencode.py"
+
+
+def load_installer():
+    spec = importlib.util.spec_from_file_location("opencode_installer", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+installer = load_installer()
+
+
+class OpenCodeInstallerTests(unittest.TestCase):
+    def test_explicit_target_bypasses_auto_discovery_and_installs_all_skills(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "custom" / "skills"
+            stdout = io.StringIO()
+
+            with mock.patch.object(
+                installer,
+                "find_opencode_skills_dir",
+                side_effect=AssertionError("explicit target must bypass auto-discovery"),
+            ):
+                with contextlib.redirect_stdout(stdout):
+                    exit_code = installer.main(["--target", str(target)])
+
+            expected_skills = {
+                path.name
+                for path in (ROOT / "skills").iterdir()
+                if path.is_dir() and not path.name.startswith(".")
+            }
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(set(installer.SKILL_NAMES), expected_skills)
+            for skill_name in expected_skills:
+                self.assertTrue((target / skill_name / "SKILL.md").is_file())
+
+    def test_without_target_uses_auto_discovery(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "detected" / "skills"
+            with mock.patch.object(
+                installer,
+                "find_opencode_skills_dir",
+                return_value=target,
+            ) as find_target:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    exit_code = installer.main([])
+
+            self.assertEqual(exit_code, 0)
+            find_target.assert_called_once_with()
+            self.assertTrue((target / "asu" / "SKILL.md").is_file())
+
+    def test_missing_auto_discovery_returns_failure(self):
+        stdout = io.StringIO()
+        with mock.patch.object(
+            installer,
+            "find_opencode_skills_dir",
+            return_value=None,
+        ):
+            with contextlib.redirect_stdout(stdout):
+                exit_code = installer.main([])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("--target", stdout.getvalue())
+
+    def test_console_messages_are_cp936_compatible(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "skills"
+            encoded_output = io.BytesIO()
+            stdout = io.TextIOWrapper(encoded_output, encoding="cp936", errors="strict")
+
+            with contextlib.redirect_stdout(stdout):
+                exit_code = installer.main(["--target", str(target)])
+            stdout.flush()
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn(b"[OK]", encoded_output.getvalue())
+
+    def test_target_requires_a_path(self):
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit) as raised:
+                installer.main(["--target"])
+
+        self.assertEqual(raised.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明

修复 OpenCode 安装脚本在自动探测目录失败时，无法使用 `--target` 指定安装位置的问题；同时避免状态 emoji 在部分 Windows CP936 控制台中触发编码异常。


## 实现内容

- 主要改动：使用 `argparse` 解析 `--target`，让显式目录优先于自动探测；自动创建目标目录并返回稳定退出码；使用兼容 CP936 的文本状态标记；增加安装器回归测试和自定义目录文档。
- 改动原因：原实现会在解析 `--target` 前因自动探测失败而退出，导致提示给用户的补救命令实际不可用。
- 影响范围：仅影响 `.opencode-plugin` 安装入口，不修改技能内容和其他插件安装方式。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查


## 验证结果

```text
python -m unittest tests.test_opencode_installer -v
# 5 tests passed

python -m unittest discover -s tests -v
# 39 tests passed

python scripts/validate_skills.py
# skills validation: 131/131 checks passed

node --test
# 3 tests passed

node --check lib/index.js
node --check scripts/inline-template.mjs
node --check scripts/export-resume-pdf.mjs
# 均通过

node scripts/inline-template.mjs --all <临时目录>
# 18 个模板构建通过

npm pack --dry-run
git diff --check
# 均通过
```

Markdown 代码块和路径已人工检查。未修改 HTML、简历模板、图片或 Logo。