### PR TITLE
ci: 自动检查全部 JavaScript 脚本语法

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -62,9 +62,9 @@ jobs:
 
       - name: Check JavaScript syntax
         run: |
-          node --check lib/index.js
-          node --check scripts/inline-template.mjs
-          node --check scripts/export-resume-pdf.mjs
+          while IFS= read -r -d '' file; do
+            node --check "$file"
+          done < <(find lib scripts -type f \( -name '*.js' -o -name '*.mjs' \) -print0)
 
       - name: Build all resume templates
         run: node scripts/inline-template.mjs --all "$RUNNER_TEMP/templates"


### PR DESCRIPTION
## 变更说明

将 CI 中硬编码的 JavaScript 语法检查改为自动发现 `lib/` 和 `scripts/` 下的全部 `.js`、`.mjs` 文件，补充当前漏检的 `scripts/kimi-webbridge.mjs`，并避免后续新增脚本时需要手动维护检查列表。

## 变更类型

- [ ] `feat`：新增功能或资源
- [ ] `fix`：修复问题
- [ ] `docs`：修改 README、贡献指南或其他文档
- [ ] `refactor`：重构目录或实现，不改变功能
- [ ] `chore`：构建、依赖或维护性修改
- [ ] `test`：新增或修改测试
- [x] `ci`：修改 CI/CD 流程或自动化检查

## 关联问题

Refs #107

## 实现内容

- 主要改动：使用 `find` 自动发现 `lib/`、`scripts/` 下所有 `.js` 和 `.mjs` 文件，并逐一运行 `node --check`。
- 改动原因：现有硬编码列表漏掉 `scripts/kimi-webbridge.mjs`，新增脚本时也容易继续漏检。
- 影响范围：仅修改 GitHub Actions 的 JavaScript 语法检查步骤，不改变 Skill、脚本或简历模板行为。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径（本次未修改这些资源）
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查
- [x] 若修改 HTML，已在浏览器中预览并检查编辑、保存、分页和导出效果（不适用：未修改 HTML）
- [x] 若修改简历模板，已确认只修改用户专属副本，没有直接改动只读母版（不适用：未修改简历模板）
- [x] 若新增图片或 Logo，已按仓库资源规范处理，没有使用低清截图或自行绘制品牌 Logo（不适用：未新增图片或 Logo）
- [x] 若提交历史中存在 `merge/revert` 操作，确认修改内容中无未处理的冲突标记（本分支无此类操作）
- [x] 若与最新主分支存在合并冲突，已保留双方有效内容并解决所有冲突，随后重新执行本清单中的检查（提交前已同步，上游无新增提交）

## 验证结果

```text
JavaScript 语法检查：
checking lib/index.js
checking scripts/inline-template.mjs
checking scripts/kimi-webbridge.mjs
checking scripts/export-resume-pdf.mjs
全部通过

python3 scripts/validate_skills.py
skills validation: 131/131 checks passed

python3 scripts/validate_skill_routing.py
skill routing validation: 26 cases passed

python3 -m unittest discover -s tests -v
Ran 39 tests — OK

node --test
3 tests passed

git diff --check
无输出，检查通过
```

## 额外说明

本 PR 只处理 JavaScript 语法检查列表的自动发现，是 Issue #107 中 CI 硬编码问题的一项聚焦修正，不尝试在同一 PR 中重构文档里的 Skill 清单。
