### PR TITLE
fix: 拒绝仓库外的技能资源路径

### DIFF
--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -104,15 +104,32 @@ def resolve_documented_resource(skill_dir: Path, target: str) -> Path:
     return (repo_root / target).resolve()
 
 
+def is_repository_file(path: Path) -> bool:
+    """Return whether a resolved file is contained by the repository."""
+    repo_root = REPO_ROOT.resolve()
+    try:
+        path.resolve().relative_to(repo_root)
+    except ValueError:
+        return False
+    return path.is_file()
+
+
 def check_documented_resources(skill_dir: Path, report: Report, text: str) -> None:
     targets = extract_documented_resource_paths(text)
     if not targets:
         report.add(True, skill_dir.name, "SKILL.md 无明确的本地资源文件引用（跳过资源检查）")
         return
-    missing = [target for target in targets
-               if not resolve_documented_resource(skill_dir, target).is_file()]
+    missing = [
+        target
+        for target in targets
+        if not is_repository_file(resolve_documented_resource(skill_dir, target))
+    ]
     if missing:
-        report.add(False, skill_dir.name, "SKILL.md 记录的资源文件不存在：" + ", ".join(missing))
+        report.add(
+            False,
+            skill_dir.name,
+            "SKILL.md 记录的资源文件不存在或位于仓库外：" + ", ".join(missing),
+        )
     else:
         report.add(True, skill_dir.name, f"SKILL.md 记录的 {len(targets)} 个资源文件均存在")
 
@@ -311,10 +328,14 @@ def check_openai_interface(skill_dir: Path, skill_name: str, manifest: dict, rep
             report.add(False, skill_name, f"agents/openai.yaml interface.{field_name} 必须是非空字符串")
             continue
         resolved = (skill_dir / value).resolve()
-        if resolved.is_file():
+        if is_repository_file(resolved):
             report.add(True, skill_name, f"agents/openai.yaml interface.{field_name} 指向存在的资源（{value}）")
         else:
-            report.add(False, skill_name, f"agents/openai.yaml interface.{field_name} 指向不存在的资源：{value}")
+            report.add(
+                False,
+                skill_name,
+                f"agents/openai.yaml interface.{field_name} 指向不存在或位于仓库外的资源：{value}",
+            )
 
 
 def check_skill(skill_dir: Path, report: Report) -> None:

--- a/tests/test_validate_skills.py
+++ b/tests/test_validate_skills.py
@@ -73,6 +73,28 @@ class OpenAIInterfaceTests(unittest.TestCase):
 
         self.assertTrue(all(result.ok for result in results))
 
+    def test_rejects_icon_outside_repository(self):
+        outside_icon = self.skill_dir / "icon.png"
+        outside_icon.write_bytes(b"png")
+        skill_dir = self.skill_dir / "repo" / "skills" / "example"
+        skill_dir.mkdir(parents=True)
+        relative_icon = "../../../icon.png"
+        manifest = {
+            "interface": {
+                "display_name": "Example",
+                "short_description": "A skill",
+                "default_prompt": "Run the skill",
+                "icon_small": relative_icon,
+            }
+        }
+
+        report = Report()
+        with patch.object(validate_skills, "REPO_ROOT", self.skill_dir / "repo"):
+            validate_skills.check_openai_interface(skill_dir, "example", manifest, report)
+
+        self.assertFalse(report.passed)
+        self.assertTrue(any("位于仓库外" in result.message for result in report.results))
+
 
 class DocumentedResourceTests(unittest.TestCase):
     def test_extracts_inline_resource_files_but_skips_examples_and_directories(self):
@@ -108,6 +130,23 @@ class DocumentedResourceTests(unittest.TestCase):
                 validate_skills.check_documented_resources(skill_dir, report, text)
             self.assertTrue(report.passed)
             self.assertIn("1 个资源文件均存在", report.results[0].message)
+
+    def test_rejects_existing_resource_outside_repository(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            repo_root = root / "repo"
+            skill_dir = repo_root / "skills" / "example"
+            skill_dir.mkdir(parents=True)
+            (root / "outside.html").write_text("<html>", encoding="utf-8")
+            text = "The skill requires `../../../outside.html`."
+            report = validate_skills.Report()
+
+            with patch.object(validate_skills, "REPO_ROOT", repo_root):
+                validate_skills.check_documented_resources(skill_dir, report, text)
+
+            self.assertFalse(report.passed)
+            self.assertIn("../../../outside.html", report.results[0].message)
+            self.assertIn("位于仓库外", report.results[0].message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 变更说明

修复技能静态校验器会接受仓库外资源路径的问题。

此前，`SKILL.md` 中记录的资源文件以及 `agents/openai.yaml` 中的图标路径只检查文件是否存在。因此，绝对路径或通过 `../` 逃出仓库的路径可能在贡献者本机通过校验，但在打包、发布或其他机器上无法使用。

## 变更类型

- [ ] `feat`：新增功能或资源
- [x] `fix`：修复问题
- [ ] `docs`：修改 README、贡献指南或其他文档
- [ ] `refactor`：重构目录或实现，不改变功能
- [ ] `chore`：构建、依赖或维护性修改
- [x] `test`：新增或修改测试
- [ ] `ci`：修改 CI/CD 流程或自动化检查

## 关联问题

无。

## 实现内容

- 主要改动：
  - 新增仓库文件边界检查；
  - 拒绝位于仓库外的 `SKILL.md` 资源文件；
  - 拒绝位于仓库外的 OpenAI 技能图标；
  - 新增两个回归测试，覆盖资源文件和图标路径逃逸。
- 改动原因：
  - 防止静态校验结果依赖贡献者本机文件；
  - 确保通过校验的资源能够随仓库正常打包和分发。
- 影响范围：
  - `scripts/validate_skills.py`
  - `tests/test_validate_skills.py`

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查
- [x] 若修改 HTML，已在浏览器中预览并检查编辑、保存、分页和导出效果（不适用：本次未修改 HTML）
- [x] 若修改简历模板，已确认只修改用户专属副本，没有直接改动只读母版（不适用：本次未修改简历模板）
- [x] 若新增图片或 Logo，已按仓库资源规范处理，没有使用低清截图或自行绘制品牌 Logo（不适用：本次未新增图片或 Logo）
- [x] 若提交历史中存在 `merge/revert` 操作，确认修改内容中无未处理的冲突标记（本次无 `merge/revert`）
- [x] 若与最新主分支存在合并冲突，已保留双方有效内容并解决所有冲突，随后重新执行本清单中的检查（当前与最新 `main` 无冲突）

## 验证结果

```text
python3 scripts/validate_skills.py
结果：120/120 checks passed

python3 -m unittest discover -s tests -v
结果：41 tests passed

node --test
结果：3 tests passed

git diff --check
结果：通过，无空白错误
```

新增的两个回归场景：

1. `SKILL.md` 引用真实存在但位于仓库外的文件时，校验必须失败；
2. `agents/openai.yaml` 的图标路径逃出仓库时，校验必须失败。

## 额外说明

本 PR 不修改任何 skill 内容、HTML 或简历模板，仅收紧现有静态校验器的资源可移植性检查。

与当前待审的 `resume/SKILL.md` frontmatter PR 不存在文件重叠。
