### PR TITLE
feat: 新增 Google Antigravity (AGY) 插件清单与安装指南

### DIFF
--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "asu-skills",
+  "version": "0.3.0",
+  "description": "中文求职工作流：开源贡献、证据复盘、项目导学面经、简历提升、同款技术简历制作、简历投递填写、面试准备和秋招进度管理。",
+  "author": {
+    "name": "Hisn0w",
+    "url": "https://github.com/Hisn00w"
+  },
+  "homepage": "https://github.com/Hisn00w/ASu-skills",
+  "repository": "https://github.com/Hisn00w/ASu-skills",
+  "license": "MIT",
+  "keywords": ["resume", "interview", "job-search", "job-application", "browser-automation", "career", "open-source", "contributor", "chinese", "great-resume", "evidence-recap"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "ASu-skills",
+    "shortDescription": "用 /contributor、/evidence-recap、/project-guide、/great-resume、/make-resume、/job-apply、/interview、/offer 完成中文求职工作流",
+    "longDescription": "ASu-skills 将开源贡献、AI 编程对话复盘、项目导学面经、简历提升、中文简历制作、简历投递填写、面试准备和秋招进度管理拆成八个可单独调用的 Antigravity skill，挂在同一个 asu-skills 插件下。",
+    "developerName": "Hisn0w",
+    "category": "Productivity",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "websiteURL": "https://github.com/Hisn00w/ASu-skills",
+    "defaultPrompt": [
+      "用 /contributor 寻找与目标岗位匹配的开源贡献机会。",
+      "用 /evidence-recap 把 AI 编程对话和交付记录整理为可核验的项目证据链。",
+      "用 /project-guide 基于项目仓库生成导学和面经。",
+      "用 /great-resume 提升我的经历并生成 HR 开场白。",
+      "用 /make-resume 默认基于 ASu 模板制作可编辑 HTML 简历，也可以指定其他模板。",
+      "用 /job-apply 通过已连接的浏览器填写求职申请，并在提交前核对。",
+      "用 /interview 根据简历预测面试问题并通过连续追问检查掌握程度。",
+      "用 /offer 记录我的秋招投递和进度。"
+    ],
+    "brandColor": "#11A683",
+    "composerIcon": "./assets/asu-circle.png",
+    "logo": "./assets/asu-circle.png"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ ASu-skills 现在是一个插件包。安装后会提供八个可单独调用的
 
 ## 安装
 
-ASu-skills 同时支持 Codex、Claude Code 和 TraeWork：仓库根目录的 `.codex-plugin/` 供 Codex 使用，`.claude-plugin/` 供 Claude Code 使用，`.trae-plugin/` 供 TraeWork 使用，三者共用同一套 `skills/`、`assets/` 和 `references/`。
+ASu-skills 同时支持 Codex、Claude Code、TraeWork 和 Google Antigravity：仓库根目录的 `.codex-plugin/` 供 Codex 使用，`.claude-plugin/` 供 Claude Code 使用，`.trae-plugin/` 供 TraeWork 使用，`.antigravity-plugin/` 供 Google Antigravity 使用，各平台共用同一套 `skills/`、`assets/` 和 `references/`。
 
 ### Codex
 
@@ -124,6 +124,23 @@ TraeWork 通过 `.trae-plugin/plugin.json` 清单把仓库打包成插件，八�
 3. 新建对话，在输入框输入 `/`，从命令列表选择 `contributor`、`evidence-recap`、`project-guide`、`great-resume`、`make-resume`、`job-apply`、`interview` 或 `offer`。
 
 其中 `<publisher>` 是插件目录下的命名空间，可自行指定（如 `local`），`<version>` 为 `plugin.json` 中的版本号。卸载时删除对应插件目录即可，不会影响你在项目或用户目录里编辑过的求职进度表。
+
+### Google Antigravity
+
+Antigravity 原生支持插件包（Plugin Bundle）和全局技能自动发现：
+
+1. **方式一：全局插件安装（推荐）**
+   把本仓库复制到 Antigravity 插件目录，保留 `.antigravity-plugin/plugin.json`、`skills/`、`assets/` 和 `references/`：
+   ```bash
+   mkdir -p ~/.gemini/config/plugins/asu-skills
+   cp -R . ~/.gemini/config/plugins/asu-skills/
+   ```
+2. **方式二：全局技能直接导入**
+   直接将 `skills/` 下的八个目录复制或链接到全局技能目录：
+   ```bash
+   cp -R skills/* ~/.gemini/config/skills/
+   ```
+3. 重启 Antigravity IDE 或新建对话，在输入框中输入 `/`，即可从命令列表选择 `contributor`、`evidence-recap`、`project-guide`、`great-resume`、`make-resume`、`job-apply`、`interview` 或 `offer`。
 
 开发者请参阅 [贡献指南](.github/CONTRIBUTING.md)，其中包含本地校验、测试命令和 PR 提交流程。
 

--- a/README_en.md
+++ b/README_en.md
@@ -74,7 +74,7 @@ ASu-skills is now a plugin pack. Installing it provides eight individually calla
 
 ## Installation
 
-ASu-skills works with Codex, Claude Code, and TraeWork: the repo root has `.codex-plugin/` for Codex, `.claude-plugin/` for Claude Code, and `.trae-plugin/` for TraeWork, all sharing the same `skills/`, `assets/`, and `references/`.
+ASu-skills works with Codex, Claude Code, TraeWork, and Google Antigravity: the repo root has `.codex-plugin/` for Codex, `.claude-plugin/` for Claude Code, `.trae-plugin/` for TraeWork, and `.antigravity-plugin/` for Google Antigravity, all sharing the same `skills/`, `assets/`, and `references/`.
 
 ### Codex
 
@@ -136,6 +136,23 @@ TraeWork packages this repository as a plugin via the `.trae-plugin/plugin.json`
 3. Start a new conversation, type `/` in the input box, and pick `contributor`, `evidence-recap`, `project-guide`, `great-resume`, `make-resume`, `job-apply`, `interview`, or `offer` from the command list.
 
 `<publisher>` is a namespace you choose under the plugin directory (for example `local`), and `<version>` is the version in `plugin.json`. To uninstall, delete the plugin directory; it never touches the application tracker you have edited in your project or user directory.
+
+### Google Antigravity
+
+Antigravity natively supports plugin bundles and individual skill discovery:
+
+1. **Option 1: Global Plugin Installation (Recommended)**:
+   Copy this repository into the Antigravity plugins directory: `~/.gemini/config/plugins/asu-skills/`, keeping `.antigravity-plugin/plugin.json`, `skills/`, `assets/`, and `references/`:
+   ```bash
+   mkdir -p ~/.gemini/config/plugins/asu-skills
+   cp -R . ~/.gemini/config/plugins/asu-skills/
+   ```
+2. **Option 2: Direct Skills Import**:
+   Copy or link the eight directories in `skills/` to your global skills directory:
+   ```bash
+   cp -R skills/* ~/.gemini/config/skills/
+   ```
+3. Restart Antigravity IDE or start a new conversation. Type `/` in the input box to pick `contributor`, `evidence-recap`, `project-guide`, `great-resume`, `make-resume`, `job-apply`, `interview`, or `offer`.
 
 For contributor checks, tests, and the PR workflow, see the [contributing guide](.github/CONTRIBUTING_en.md).
 


### PR DESCRIPTION
## 变更说明

新增对 Google Antigravity (AGY) 智能体开发环境的适配支持，补充对应的插件清单与中英文安装使用指南。

## 变更类型

- [x] `feat`：新增功能或资源
- [x] `docs`：修改 README、贡献指南或其他文档

## 关联问题

无

## 实现内容

- 主要改动：
  1. 新增 `.antigravity-plugin/plugin.json` 插件清单；
  2. 在 `README.md` 与 `README_en.md` 的支持平台列表中加入 Google Antigravity；
  3. 补充 Antigravity 全局插件安装与技能直接导入说明。
- 改动原因：让 ASu-skills 支持在 Google Antigravity 环境下被识别并加载。
- 影响范围：纯增量适配，不影响现有 Codex、Claude Code、TraeWork 等平台的任何功能。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查（120/120 checks passed）

## 验证结果

本地运行 `python3 scripts/validate_skills.py` 静态校验通过：
```text
skills validation: 120/120 checks passed
```

## 额外说明

无
