### PR TITLE
fix(project-guide): reject missing descriptions and non-text input ♡

### DIFF
--- a/scripts/project_guide.py
+++ b/scripts/project_guide.py
@@ -115,6 +115,17 @@ def load_json(path: Path) -> dict[str, Any]:
     return data
 
 
+def read_json_text(payload: dict[str, Any], key: str, alias: Optional[str] = None) -> str:
+    if key not in payload and alias is not None:
+        key = alias
+    value = payload.get(key)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"JSON field '{key}' must be a string or null")
+    return value.strip()
+
+
 def build_prompt(
     description: str,
     short_name: Optional[str] = None,
@@ -231,7 +242,7 @@ def command_check(args: argparse.Namespace) -> int:
 
 
 def command_build_prompt(args: argparse.Namespace) -> int:
-    description = args.description or ""
+    description = (args.description or "").strip()
     short_name = args.short_name or ""
     tech = args.tech or ""
     role = args.role or ""
@@ -240,14 +251,14 @@ def command_build_prompt(args: argparse.Namespace) -> int:
     if args.json_file:
         try:
             payload = load_json(Path(args.json_file))
+            description = read_json_text(payload, "description")
+            short_name = read_json_text(payload, "short_name", "简称")
+            tech = read_json_text(payload, "tech_stack", "tech")
+            role = read_json_text(payload, "role_focus", "role")
+            extra = read_json_text(payload, "extra")
         except (OSError, json.JSONDecodeError, ValueError) as exc:
             print(f"Error loading JSON: {exc}", file=sys.stderr)
             return 1
-        description = str(payload.get("description", "")).strip()
-        short_name = str(payload.get("short_name", payload.get("简称", ""))).strip()
-        tech = str(payload.get("tech_stack", payload.get("tech", ""))).strip()
-        role = str(payload.get("role_focus", payload.get("role", ""))).strip()
-        extra = str(payload.get("extra", "")).strip()
 
     try:
         short_name = validate_short_name(short_name)

--- a/tests/test_project_guide.py
+++ b/tests/test_project_guide.py
@@ -121,6 +121,86 @@ class ProjectGuideTests(unittest.TestCase):
         self.assertIn("Python, Markdown", output)
         self.assertIn("/project-guide", output)
 
+    def run_build_prompt(self, args):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            exit_code = project_guide.main(["build-prompt", *args])
+        return exit_code, stdout.getvalue(), stderr.getvalue()
+
+    def run_build_prompt_json(self, payload):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            json_file = Path(temp_dir) / "input.json"
+            json_file.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+            return self.run_build_prompt(["--json-file", str(json_file)])
+
+    def test_build_prompt_rejects_blank_cli_description(self):
+        for description in ("", "   ", "\t\n", "\u3000"):
+            with self.subTest(description=description):
+                code, output, error = self.run_build_prompt(["-d", description])
+                self.assertEqual(code, 1)
+                self.assertEqual(output, "")
+                self.assertIn("missing description", error)
+
+    def test_build_prompt_rejects_missing_json_description(self):
+        for payload in ({}, {"description": None}, {"description": " \t\n"}):
+            with self.subTest(payload=payload):
+                code, output, error = self.run_build_prompt_json(payload)
+                self.assertEqual(code, 1)
+                self.assertEqual(output, "")
+                self.assertIn("missing description", error)
+
+    def test_build_prompt_rejects_non_string_json_fields(self):
+        fields = ("description", "short_name", "简称", "tech_stack", "tech", "role_focus", "role", "extra")
+        for field in fields:
+            for value in ([], {}, 0, 42, False, True):
+                with self.subTest(field=field, value=value):
+                    code, output, error = self.run_build_prompt_json(
+                        {"description": "负责项目分析与面试准备", field: value}
+                    )
+                    self.assertEqual(code, 1)
+                    self.assertEqual(output, "")
+                    self.assertIn(field, error)
+                    self.assertIn("must be a string", error)
+
+    def test_build_prompt_optional_nulls_match_omitted_fields(self):
+        description = "负责项目分析与面试准备"
+        baseline = self.run_build_prompt_json({"description": description})
+        self.assertEqual(baseline[0], 0)
+        self.assertEqual(baseline[2], "")
+        for fields in (
+            ("short_name", "tech_stack", "role_focus", "extra"),
+            ("简称", "tech", "role", "extra"),
+        ):
+            with self.subTest(fields=fields):
+                payload = {"description": description, **dict.fromkeys(fields)}
+                self.assertEqual(self.run_build_prompt_json(payload), baseline)
+
+    def test_build_prompt_json_aliases_match_cli_input(self):
+        cli = self.run_build_prompt([
+            "-d", "  负责项目分析与面试准备  ", "-s", " 导学 ",
+            "--tech", " Python ", "--role", " AI ", "--extra", " 补充说明 ",
+        ])
+        self.assertEqual(cli[0], 0)
+        self.assertEqual(cli[2], "")
+        self.assertIn("```text\n负责项目分析与面试准备\n```", cli[1])
+        self.assertEqual(self.run_build_prompt_json({
+            "description": "  负责项目分析与面试准备  ", "简称": " 导学 ",
+            "tech": " Python ", "role": " AI ", "extra": " 补充说明 ",
+        }), cli)
+
+    def test_build_prompt_json_canonical_fields_take_precedence(self):
+        payload = {
+            "description": "负责项目分析与面试准备", "short_name": "导学",
+            "tech_stack": "Python", "role_focus": "AI",
+        }
+        baseline = self.run_build_prompt_json(payload)
+        self.assertEqual(baseline[0], 0)
+        self.assertEqual(baseline[2], "")
+        self.assertEqual(self.run_build_prompt_json({
+            **payload, "简称": "旧简称", "tech": "旧技术栈", "role": "旧方向",
+        }), baseline)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/41b463f6-41f8-4387-abbd-0710417338a8" alt="Thumbs up" width="64">

`build-prompt` turns JSON `null` into the string `None`, so a missing project description passes validation. A whitespace-only CLI description is also accepted.

To reproduce, save `{"description": null}` as `input.json` and run either command:

```bash
python3 scripts/project_guide.py build-prompt --json-file input.json
python3 scripts/project_guide.py build-prompt -d '   '
```

Both currently exit 0 and generate a prompt. This patch makes them exit 1 with a missing-description error and no stdout. It also rejects non-text JSON fields and treats optional `null` values as omitted. Valid output and field aliases keep their existing behavior.

Added regression tests for these cases, including alias precedence. Local checks passed:

```text
python3 -m unittest discover -s tests -v   # 47 passed
node --test                              # 3 passed
```

<details>
<summary>Contribution checklist</summary>

- [x] Read `AGENTS.md`.
- [x] Read `.github/CONTRIBUTING.md`.
- [ ] Chinese commit wording: this commit uses English with the required Conventional Commits format.
- [x] No secrets, private data, temporary files, or unrelated changes in the diff.
- [x] Documentation and resource paths: unchanged.
- [x] Skill/routing validators, syntax checks, template builds, package dry run, and `git diff --check` passed.
- [x] HTML preview: N/A, no HTML changes.
- [x] Read-only resume master: unchanged.
- [x] Image/logo rules: N/A, no repository assets changed.
- [x] No merge/revert operations or conflict markers.
- [x] No conflicts against upstream `143a661` at submission.

</details>
