### PR TITLE
docs(opencode): 修正手动安装路径与目录准备步骤

### DIFF
--- a/.opencode-plugin/installation-guide.md
+++ b/.opencode-plugin/installation-guide.md
@@ -25,19 +25,31 @@ python .opencode-plugin/install-opencode.py --target /custom/opencode/skills
 
 ## 方法 2：手动安装
 
-```bash
-# 1. 克隆仓库
+先 clone 并进入仓库：
+
+```text
 git clone https://github.com/Hisn00w/ASu-skills.git
-
-# 2. 复制 skills 到 OpenCode 目录
-# Windows
-xcopy /E /I skills\* E:\Cache\skills\
-
-# macOS / Linux
-cp -r skills/* ~/.config/opencode/skills/
-
-# 3. 重启 OpenCode 或执行 /reload-plugins
+cd ASu-skills
 ```
+
+根据终端选择对应的复制命令。
+
+**Windows（CMD / 命令提示符）：**
+
+```bat
+xcopy /E /I "skills\*" "%USERPROFILE%\.config\opencode\skills"
+```
+
+`/I` 会将不存在的目标视为目录并创建；路径引号用于兼容包含空格的用户名。
+
+**macOS / Linux（Bash / Zsh）：**
+
+```bash
+mkdir -p "$HOME/.config/opencode/skills"
+cp -r skills/* "$HOME/.config/opencode/skills/"
+```
+
+复制完成后重启 OpenCode。
 
 ## 方法 3：通过 OpenCode 插件管理器（如果支持）
 
@@ -63,6 +75,6 @@ cp -r skills/* ~/.config/opencode/skills/
 
 ## 注意事项
 
-- OpenCode skills 目录默认在 `E:\Cache\skills\`（Windows）或 `~/.config/opencode/skills/`（macOS/Linux）
+- [OpenCode 默认全局技能目录](https://opencode.ai/docs/skills/#place-files)为 `~/.config/opencode/skills/`；Windows CMD 中使用 `%USERPROFILE%\.config\opencode\skills`。如已配置自定义目录，请替换示例中的目标路径。
 - 安装后需重启 OpenCode 或执行 `/reload-plugins`
 - 每个 skill 需要在 OpenCode 中配置触发词才能通过 `/` 菜单调用


### PR DESCRIPTION
## 变更说明

手动安装步骤在 clone 后未进入仓库，复制命令找不到 `skills/`。Windows 示例还写死了 `E:\Cache\skills`，macOS/Linux 则未创建首次安装需要的目标目录。

## 变更类型

- [x] docs：修改安装文档

## 关联问题

无。

## 实现内容

- clone 后增加 `cd ASu-skills`，按终端拆分复制命令。
- Windows CMD 改用 `"%USERPROFILE%\.config\opencode\skills"`，通过 `xcopy /I` 创建目标目录，并为路径加引号。
- macOS/Linux 复制前创建目标目录，为用户目录路径加引号。
- 同步修正默认目录说明，仅修改 `.opencode-plugin/installation-guide.md`。

## 检查清单

- [x] 已阅读根目录 [AGENTS.md](https://github.com/Hisn00w/ASu-skills/blob/main/AGENTS.md)。
- [x] 已阅读 [.github/CONTRIBUTING.md](https://github.com/Hisn00w/ASu-skills/blob/main/.github/CONTRIBUTING.md)。
- [x] 已运行 `git diff --check`。
- [x] 已检查修改内容中没有冲突标记。
- [x] 已检查没有密钥、个人隐私、临时文件或无关改动。
- [x] 已预览 Markdown，确认代码块、链接及路径显示正常。
- [x] 已完成相关检查；本次未改动 skill/JSON，技能校验器通过。
- [x] HTML 浏览器预览：不适用，本次未修改 HTML。
- [x] 基于最新 `main` 创建分支，已确认无合并冲突。

## 验证结果

- macOS：新建目录、用户路径含空格、重复安装均通过；8 个技能、27 个文件与源内容一致，其他技能未受影响。
- Windows：按 [OpenCode 技能目录说明](https://opencode.ai/docs/skills/#place-files)及 [Microsoft xcopy 文档](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/xcopy)核对路径和参数。
- Markdown 预览、技能校验、`git diff --check`、补丁适用性检查：通过。

## 额外说明

未改动自动安装脚本。
