### PR TITLE
docs: 强化 /contributor 撞车检查，改为枚举与交叉验证

### DIFF
--- a/skills/contributor/SKILL.md
+++ b/skills/contributor/SKILL.md
@@ -38,7 +38,7 @@ description: GitHub 开源贡献辅助技能：围绕目标岗位和技术栈发
 ## 贡献工作流
 
 1. 在 GitHub 搜索与目标岗位、技术栈或用户指定方向匹配，且有近期维护迹象并允许外部贡献的项目。优先检查项目主页、默认分支活动、许可证、`CONTRIBUTING`、issue/PR 状态和明确的贡献入口；此阶段只读，不 fork、不 push。
-2. 从 issue、讨论、README、docs、examples、tests 和代码注释中寻找真实、范围清晰且能够在本地验证的问题。优先处理用户可以复现、项目确实需要、又不会牵涉大范围设计的改动；同时搜索 open/closed issue、PR、提交历史和必要的 blame，避免撞车。
+2. 从 issue、讨论、README、docs、examples、tests 和代码注释中寻找真实、范围清晰且能够在本地验证的问题。优先处理用户可以复现、项目确实需要、又不会牵涉大范围设计的改动；同时搜索提交历史和必要的 blame，确认上游默认分支尚未修复。撞车判定以目标 issue 的 linked PR（`gh api repos/<owner>/<repo>/issues/<N>/timeline`）和 open PR 全量标题（`gh pr list --state open`）为准，关键词搜索仅作补充，候选较多或标题含糊时再按拟改文件路径过滤；发现相同问题或相同方案的 PR 即按第 3 步降级或丢弃。
 3. 快速看一遍 `CONTRIBUTING` 和仓库里的代理说明；如果规则明确禁止 typo-only、drive-by documentation 或当前拟议的 PR 类型，标记为 `ineligible` 并丢弃，不进入待确认候选清单。如果规则要求先 claim issue、取得 maintainer approval 或先开 issue，则标记为 `blocked`，写明待满足的前置条件；在条件满足前不创建分支或 patch。只有项目规则不允许或目标明显不匹配时才使用 `ineligible`；满足前置条件本身如需外部写操作，也必须按第 5 步逐项确认。否则形成候选清单，写明目标仓库、问题、拟修改文件、验证方式和潜在影响。
    为了让候选可以横向比较，记录 issue 创建时间、最近实质更新、当前状态、assignees、评论中的认领、相关 open/closed PR 以及当前上游代码证据。issue 时间较久、已有明确认领或相同方案的 PR、尚未取得仓库建议的 approval/assignment，或需要 GPU/专有服务才能复现或验证时，可适当降低优先级并标注风险。
 4. 每个候选在准备本地改动或 patch 前，都从当前上游基线创建独立专用分支；不得修改默认分支，也不得把下一份补丁堆叠到已有 PR 分支。随后在该分支上实际应用拟议的最小改动或 patch。提交前先检查仓库的 `CONTRIBUTING`、`.github/workflows/`、项目级工具配置以及项目级的 pre-commit 配置（存在时），根据仓库实际配置确定与当前改动相关的验证命令，再运行可执行的测试、lint、格式、构建或链接检查，并记录结果；纯文档小修至少检查 diff 和 Markdown，然后把完整 diff 展示给用户。


### PR DESCRIPTION
## 变更说明

让 /contributor 的撞车检查从“关键词搜索”升级为可穷举的枚举与交叉验证：以目标 issue 的 linked PR 和 open PR 全量标题为准，关键词搜索仅作补充。实际案例：在为某仓库的一个 open issue 准备修复时，两次关键词搜索均未命中，据此判定无撞车并完成了整轮修复与测试，最后靠人工核对 open PR 全量标题才发现同天已有同方案 PR——其标题本含所搜关键词，只是搜索排序未把它送进结果集。

## 变更类型

- [ ] `feat`：新增功能或资源
- [ ] `fix`：修复问题
- [x] `docs`：修改 README、贡献指南或其他文档
- [ ] `refactor`：重构目录或实现，不改变功能
- [ ] `chore`：构建、依赖或维护性修改
- [ ] `test`：新增或修改测试
- [ ] `ci`：修改 CI/CD 流程或自动化检查

## 关联问题

无

## 实现内容

- 主要改动：
  - 撞车判定改为两条可穷举路径：`gh api repos/<owner>/<repo>/issues/<N>/timeline` 读目标 issue 的 linked / cross-referenced PR（不依赖标题措辞）；`gh pr list --state open` 全量枚举 open PR 标题。
  - 关键词搜索降级为补充手段，候选较多或标题含糊时再按拟改文件路径做文件级过滤。
  - 发现相同问题或相同方案的 PR 即按第 3 步降级或丢弃；提交历史/blame 检查单独保留，用于确认上游默认分支尚未修复。
- 改动原因：issue timeline 与 PR 全量列表不依赖任何措辞，单次调用即可完成，成本低且可复核。
- 影响范围：仅修改 skills/contributor/SKILL.md 贡献工作流第 2 步的撞车检查方法；不改变外部写操作的确认边界，不新增自动化流程。

## 检查清单

提交 PR 前请完成以下检查。无法完成的项目必须在“验证结果”中说明原因和替代方案。

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查
- [ ] 若修改 HTML，已在浏览器中预览并检查编辑、保存、分页和导出效果（不适用：本次仅修改 Markdown）
- [ ] 若修改简历模板，已确认只修改用户专属副本，没有直接改动只读母版（不适用）
- [ ] 若新增图片或 Logo，已按仓库资源规范处理，没有使用低清截图或自行绘制品牌 Logo（不适用）
- [x] 若提交历史中存在 `merge/revert` 操作，确认修改内容中无未处理的冲突标记（`<<<<<<<`、`=======`、`>>>>>>>`）（本次提交历史无 merge/revert）
- [x] 若与最新主分支存在合并冲突，已保留双方有效内容并解决所有冲突，随后重新执行本清单中的检查（基于最新 main，无冲突）

## 验证结果

```text
$ python scripts/validate_skills.py
exit=0，120 项全部 PASS（含 skills/contributor frontmatter 与插件清单校验）

$ git diff --check
无输出（无空白错误）

$ git diff origin/main HEAD --stat
skills/contributor/SKILL.md | 2 +-
1 file changed, 1 insertion(+), 1 deletion(-)
```

## 额外说明

无
