### PR TITLE
Refactor/skills registry: 将技能入口目录收敛为 skills.registry.json 单一事实源并接入 CI 校验

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,10 +8,7 @@
   "plugins": [
     {
       "name": "asu-skills",
-      "source": "./",
-      "displayName": "ASu-skills",
-      "description": "用 /contributor、/evidence-recap、/project-guide、/great-resume、/make-resume、/job-match、/job-apply、/interview、/offer 完成中文求职工作流。",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "author": {
         "name": "Hisn0w",
         "url": "https://github.com/Hisn00w"
@@ -19,22 +16,29 @@
       "homepage": "https://github.com/Hisn00w/ASu-skills",
       "repository": "https://github.com/Hisn00w/ASu-skills",
       "license": "MIT",
-      "category": "Productivity",
       "keywords": [
-        "project-guide",
-        "project-analysis",
         "resume",
-        "interview",
         "job-search",
+        "job-match",
         "job-application",
         "browser-automation",
         "career",
         "open-source",
-        "contributor",
         "chinese",
+        "project-analysis",
+        "contributor",
+        "evidence-recap",
+        "project-guide",
         "great-resume",
-        "evidence-recap"
-      ]
+        "make-resume",
+        "job-apply",
+        "interview",
+        "offer"
+      ],
+      "source": "./",
+      "displayName": "ASu-skills",
+      "description": "用 /contributor、/evidence-recap、/project-guide、/great-resume、/make-resume、/job-match、/job-apply、/interview、/offer 完成中文求职工作流。",
+      "category": "Productivity"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "asu-skills",
   "displayName": "ASu-skills",
-  "description": "中文求职工作流：开源贡献、证据复盘、项目导学面经、简历提升、简历制作、岗位匹配、简历投递填写、面试准备和秋招进度管理。",
-  "version": "0.3.0",
+  "description": "中文求职工作流：开源贡献、证据复盘、项目导学面经、简历提升、简历制作、岗位匹配、简历投递填写、面试准备和校招进度管理。",
+  "version": "0.4.0",
   "author": {
     "name": "Hisn0w",
     "url": "https://github.com/Hisn00w"
@@ -11,19 +11,22 @@
   "repository": "https://github.com/Hisn00w/ASu-skills",
   "license": "MIT",
   "keywords": [
-    "project-guide",
-    "project-analysis",
     "resume",
-    "interview",
     "job-search",
     "job-match",
     "job-application",
     "browser-automation",
     "career",
     "open-source",
-    "contributor",
     "chinese",
+    "project-analysis",
+    "contributor",
+    "evidence-recap",
+    "project-guide",
     "great-resume",
-    "evidence-recap"
+    "make-resume",
+    "job-apply",
+    "interview",
+    "offer"
   ]
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "asu-skills",
-  "version": "0.3.0",
-  "description": "中文求职工作流：开源贡献、证据复盘、项目导学面经、简历提升、简历制作、岗位匹配、简历投递填写、面试准备和秋招进度管理。",
+  "version": "0.4.0",
   "author": {
     "name": "Hisn0w",
     "url": "https://github.com/Hisn00w"
@@ -9,15 +8,37 @@
   "homepage": "https://github.com/Hisn00w/ASu-skills",
   "repository": "https://github.com/Hisn00w/ASu-skills",
   "license": "MIT",
-  "keywords": ["resume", "interview", "job-search", "job-match", "job-application", "browser-automation", "career", "open-source", "contributor", "chinese", "great-resume", "evidence-recap"],
+  "keywords": [
+    "resume",
+    "job-search",
+    "job-match",
+    "job-application",
+    "browser-automation",
+    "career",
+    "open-source",
+    "chinese",
+    "project-analysis",
+    "contributor",
+    "evidence-recap",
+    "project-guide",
+    "great-resume",
+    "make-resume",
+    "job-apply",
+    "interview",
+    "offer"
+  ],
+  "description": "中文求职工作流：开源贡献、证据复盘、项目导学面经、简历提升、简历制作、岗位匹配、简历投递填写、面试准备和校招进度管理。",
   "skills": "./skills/",
   "interface": {
     "displayName": "ASu-skills",
     "shortDescription": "用 /contributor、/evidence-recap、/project-guide、/great-resume、/make-resume、/job-match、/job-apply、/interview、/offer 完成中文求职工作流",
-    "longDescription": "ASu-skills 将开源贡献、AI 编程对话复盘、项目导学面经、简历提升、中文简历制作、岗位匹配、简历投递填写、面试准备和秋招进度管理拆成九个可单独调用的 Codex skill。",
+    "longDescription": "ASu-skills 将开源贡献、证据复盘、项目导学面经、简历提升、简历制作、岗位匹配、简历投递填写、面试准备和校招进度管理拆成九个可单独调用的 Codex skill。",
     "developerName": "Hisn0w",
     "category": "Productivity",
-    "capabilities": ["Interactive", "Write"],
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
     "websiteURL": "https://github.com/Hisn00w/ASu-skills",
     "defaultPrompt": [
       "用 /contributor 寻找与目标岗位匹配的开源贡献机会。",

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,6 +15,7 @@
    - Markdown 改动在本地渲染预览；
    - HTML 模板在浏览器中打开，确认可编辑、可保存，并可导出 A4；
    - 涉及 `SKILL.md`、`agents/openai.yaml`、插件清单或新增 skill 时，在仓库根目录运行 `python3 scripts/validate_skills.py`，确认 frontmatter、元数据与资源引用校验通过；
+   - 新增、删除或重命名 skill 入口时，先更新根目录 `skills.registry.json`，再运行 `npm run sync:skills` 同步各插件清单、安装脚本、Issue 模板与 README 总览，并确认 `npm run sync:skills -- --check` 通过；
 4. 提交信息遵循 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)，使用 `feat:`、`fix:`、`docs:` 等英文类型前缀，并附简洁、具体的中文标题；
 5. 创建 Pull Request 前，请完整阅读本文件与 [`PULL_REQUEST_TEMPLATE.md`](PULL_REQUEST_TEMPLATE.md)，并逐项完成模板中的检查清单；
 6. Pull Request 描述应说明改动内容、变更原因与验证方式；如确有无法完成的检查项，请说明原因并提供替代验证方式。
@@ -27,7 +28,7 @@
 python3 scripts/validate_skills.py
 ```
 
-校验内容包括：`SKILL.md` 是否存在、frontmatter 是否可解析、`name` 是否与目录名一致、`description` 是否非空且不过长、`agents/openai.yaml` 是否可解析、`SKILL.md` 引用的本地 `references/assets` 路径是否存在，以及 Codex、TraeWork、Claude Code、OpenCode 插件清单是否为合法 JSON 并覆盖必要入口。GitHub Actions 会在涉及 `skills/**` 等路径的 Pull Request 上自动运行该校验。
+校验内容包括：`SKILL.md` 是否存在、frontmatter 是否可解析、`name` 是否与目录名一致、`description` 是否非空且不过长、`agents/openai.yaml` 是否可解析、`SKILL.md` 引用的本地 `references/assets` 路径是否存在，以及 Codex、TraeWork、Claude Code、OpenCode 插件清单是否为合法 JSON 并覆盖必要入口。入口清单以根目录 `skills.registry.json` 为单一事实源；新增/调整入口时先更新该文件并运行 `npm run sync:skills`，GitHub Actions 会以 `node scripts/sync-skill-catalog.mjs --check` 校验所有派生清单一致。该校验会在涉及 `skills/**` 等路径的 Pull Request 上自动运行。
 
 路由回归用例存放在 `tests/skill-routing-cases.yaml`，记录各求职入口的预期路由，由 GitHub Actions 执行不调用 LLM 的确定性 schema 校验。校验会检查 YAML 结构、用例字段、重复 prompt，以及 `expected` 是否对应 `skills/` 下的实际目录；它不判断 prompt 的语义路由结果。
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@
    - Markdown 改动在本地渲染预览；
    - HTML 模板在浏览器中打开，确认可编辑、可保存，并可导出 A4；
    - 涉及 `SKILL.md`、`agents/openai.yaml`、插件清单或新增 skill 时，在仓库根目录运行 `python3 scripts/validate_skills.py`，确认 frontmatter、元数据与资源引用校验通过；
-   - 新增、删除或重命名 skill 入口时，先更新根目录 `skills.registry.json`，再运行 `npm run sync:skills` 同步各插件清单、安装脚本、Issue 模板与 README 总览，并确认 `npm run sync:skills -- --check` 通过；
+   - 新增、删除或重命名 skill 入口时，先更新根目录 `skills.registry.json`，再运行 `npm run sync:skills` 同步各插件清单、安装脚本、Issue 模板与 README 总览，并确认 `npm run sync:skills --check` 通过；
 4. 提交信息遵循 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)，使用 `feat:`、`fix:`、`docs:` 等英文类型前缀，并附简洁、具体的中文标题；
 5. 创建 Pull Request 前，请完整阅读本文件与 [`PULL_REQUEST_TEMPLATE.md`](PULL_REQUEST_TEMPLATE.md)，并逐项完成模板中的检查清单；
 6. Pull Request 描述应说明改动内容、变更原因与验证方式；如确有无法完成的检查项，请说明原因并提供替代验证方式。

--- a/.github/CONTRIBUTING_en.md
+++ b/.github/CONTRIBUTING_en.md
@@ -15,6 +15,7 @@ Contributions via Issues and Pull Requests are welcome. To keep collaboration qu
    - Preview Markdown changes locally;
    - Open HTML templates in a browser and confirm they edit, save, and export to A4;
    - When touching `SKILL.md`, `agents/openai.yaml`, plugin manifests, or adding a new skill, run `python3 scripts/validate_skills.py` from the repository root and confirm frontmatter, metadata, and resource references pass validation;
+   - When adding, removing, or renaming a skill entry, first update `skills.registry.json`, then run `npm run sync:skills` to regenerate every plugin manifest, installer, issue template, and README overview, and confirm `npm run sync:skills -- --check` passes;
 4. Commit with [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/): use English type prefixes such as `feat:`, `fix:`, `docs:`, with a short, specific title;
 5. Before opening a Pull Request, read this file and [`PULL_REQUEST_TEMPLATE.md`](PULL_REQUEST_TEMPLATE.md) in full, and complete every item in the template's checklist;
 6. The Pull Request description should state what changed, why, and how it was verified. If you cannot complete a checklist item, explain why and offer an alternative verification.
@@ -27,7 +28,7 @@ After modifying `SKILL.md`, `agents/openai.yaml`, plugin manifests, or adding a 
 python3 scripts/validate_skills.py
 ```
 
-The validator checks that each `SKILL.md` exists; its frontmatter parses; `name` matches the directory name; `description` is non-empty and not too long; `agents/openai.yaml` parses; local `references/assets` paths cited in `SKILL.md` exist; and the Codex, TraeWork, Claude Code, and OpenCode plugin manifests are valid JSON covering the required entries. GitHub Actions runs this validator automatically on Pull Requests that touch `skills/**` and related paths.
+The validator checks that each `SKILL.md` exists; its frontmatter parses; `name` matches the directory name; `description` is non-empty and not too long; `agents/openai.yaml` parses; local `references/assets` paths cited in `SKILL.md` exist; and the Codex, TraeWork, Claude Code, and OpenCode plugin manifests are valid JSON covering the required entries. The entry catalog is maintained in `skills.registry.json` as the single source of truth; after adding or adjusting entries, update that file and run `npm run sync:skills`. GitHub Actions also runs `node scripts/sync-skill-catalog.mjs --check` on Pull Requests that touch `skills/**` and related paths.
 
 Routing regression cases live in `tests/skill-routing-cases.yaml`. GitHub Actions validates their YAML structure, fields, duplicate prompts, and whether `expected` maps to an actual directory under `skills/`, without calling an LLM; it does not judge the semantic routing result.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,12 +25,17 @@ body:
       label: 相关技能
       description: 问题与哪个技能相关？
       options:
+# catalog:issue.bug.options:begin
         - /contributor 开源贡献
         - /evidence-recap 证据复盘
+        - /project-guide 项目导学面经
         - /great-resume 简历提升
         - /make-resume 简历制作
-        - /interview 面试预测
-        - /offer 秋招进度管理
+        - /job-match 岗位匹配
+        - /job-apply 简历投递填写
+        - /interview 面试准备
+        - /offer 校招进度管理
+# catalog:issue.bug.options:end
         - 不涉及具体技能
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,12 +13,17 @@ body:
       label: 相关技能
       description: 这个功能与哪个技能相关？
       options:
+# catalog:issue.feature.options:begin
         - /contributor 开源贡献
         - /evidence-recap 证据复盘
+        - /project-guide 项目导学面经
         - /great-resume 简历提升
         - /make-resume 简历制作
-        - /interview 面试预测
-        - /offer 秋招进度管理
+        - /job-match 岗位匹配
+        - /job-apply 简历投递填写
+        - /interview 面试准备
+        - /offer 校招进度管理
+# catalog:issue.feature.options:end
         - 不涉及具体技能
     validations:
       required: true

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -8,6 +8,7 @@ on:
       - '.trae-plugin/**'
       - '.claude-plugin/**'
       - '.opencode-plugin/**'
+      - 'skills.registry.json'
       - 'package.json'
       - 'assets/templates-html/**'
       - 'lib/**'
@@ -23,6 +24,7 @@ on:
       - '.trae-plugin/**'
       - '.claude-plugin/**'
       - '.opencode-plugin/**'
+      - 'skills.registry.json'
       - 'package.json'
       - 'assets/templates-html/**'
       - 'lib/**'
@@ -56,6 +58,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.19.0'
+
+      - name: Check skill catalog sync
+        run: node scripts/sync-skill-catalog.mjs --check
 
       - name: Run JavaScript tests
         run: node --test

--- a/.opencode-plugin/install-opencode.py
+++ b/.opencode-plugin/install-opencode.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 """
 ASu-skills OpenCode 安装脚本
 自动将 skills/ 目录复制到 OpenCode 的 skills 目录
@@ -10,6 +10,7 @@ import shutil
 from pathlib import Path
 
 
+# catalog:opencode.skills:begin
 SKILL_NAMES = (
     "contributor",
     "evidence-recap",
@@ -21,6 +22,10 @@ SKILL_NAMES = (
     "interview",
     "offer",
 )
+# catalog:opencode.skills:end
+# catalog:opencode.echo:begin
+TRIGGER_WORDS = "/contributor  /evidence-recap  /project-guide  /great-resume  /make-resume  /job-match  /job-apply  /interview  /offer"
+# catalog:opencode.echo:end
 
 
 def find_opencode_skills_dir():
@@ -107,7 +112,7 @@ def install_skills(skills_dir, source_dir):
 
     print()
     print("[OK] 安装完成！请重启 OpenCode 或执行 /reload-plugins")
-    print("   使用触发词：/contributor  /evidence-recap  /project-guide  /great-resume  /make-resume  /job-match  /job-apply  /interview  /offer")
+    print("   使用触发词：" + TRIGGER_WORDS)
     return True
 
 

--- a/.opencode-plugin/installation-guide.md
+++ b/.opencode-plugin/installation-guide.md
@@ -66,6 +66,7 @@ cp -r skills/* "$HOME/.config/opencode/skills/"
 |---------|--------|
 | 简历提升 | /great-resume、我要酥化、改写经历 |
 | 简历制作 | /make-resume、做简历、同款简历、指定模板 |
+| 岗位匹配 | /job-match、JD 匹配、简历差距、是否值得投递 |
 | 面试准备 | /interview、面试预测、模拟面试 |
 | 求职进度 | /offer、秋招进度 |
 | 简历投递填写 | /job-apply、自动填写招聘网站申请表 |

--- a/.opencode-plugin/plugin.json
+++ b/.opencode-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "asu-skills",
-  "version": "0.3.0",
-  "description": "中文求职工作流插件：开源贡献、证据复盘、项目导学面经、简历提升、简历制作、岗位匹配、简历投递填写、面试准备和秋招进度管理。",
+  "version": "0.4.0",
   "author": {
     "name": "Hisn0w",
     "url": "https://github.com/Hisn00w"
@@ -9,19 +8,65 @@
   "homepage": "https://github.com/Hisn00w/ASu-skills",
   "repository": "https://github.com/Hisn00w/ASu-skills",
   "license": "MIT",
-  "keywords": ["resume", "interview", "job-search", "job-match", "job-application", "browser-automation", "career", "open-source", "contributor", "chinese", "great-resume", "evidence-recap"],
+  "keywords": [
+    "resume",
+    "job-search",
+    "job-match",
+    "job-application",
+    "browser-automation",
+    "career",
+    "open-source",
+    "chinese",
+    "project-analysis",
+    "contributor",
+    "evidence-recap",
+    "project-guide",
+    "great-resume",
+    "make-resume",
+    "job-apply",
+    "interview",
+    "offer"
+  ],
+  "description": "中文求职工作流插件：开源贡献、证据复盘、项目导学面经、简历提升、简历制作、岗位匹配、简历投递填写、面试准备和校招进度管理。",
   "skills": {
     "path": "./skills",
     "entries": [
-      {"name": "contributor", "description": "开源贡献：寻找目标岗位匹配的开源贡献机会"},
-      {"name": "evidence-recap", "description": "证据复盘：把 AI 编程对话和交付记录整理为可核验的项目证据链"},
-      {"name": "project-guide", "description": "项目导学面经：基于项目仓库生成导学和面经双文件"},
-      {"name": "great-resume", "description": "简历提升：把真实经历重组为岗位定位、简历要点、HR开场白"},
-      {"name": "make-resume", "description": "简历制作：默认使用 ASu 模板，也可指定其他模板，生成可编辑 HTML 简历并提供 PDF 导出"},
-      {"name": "job-match", "description": "岗位匹配：对照 JD 与真实经历生成证据矩阵和投递建议"},
-      {"name": "job-apply", "description": "简历投递填写：通过已连接的浏览器填写申请并在提交前核对"},
-      {"name": "interview", "description": "面试预测：简历驱动的面试问题预测与连续追问"},
-      {"name": "offer", "description": "秋招进度管理：记录投递、面试、offer 状态"}
+      {
+        "name": "contributor",
+        "description": "开源贡献：寻找目标岗位匹配的开源贡献机会"
+      },
+      {
+        "name": "evidence-recap",
+        "description": "证据复盘：把 AI 编程对话和交付记录整理为可核验的项目证据链"
+      },
+      {
+        "name": "project-guide",
+        "description": "项目导学面经：基于项目仓库生成导学和面经双文件"
+      },
+      {
+        "name": "great-resume",
+        "description": "简历提升：把真实经历重组为岗位定位、简历要点、HR开场白"
+      },
+      {
+        "name": "make-resume",
+        "description": "简历制作：默认使用 ASu 模板，也可指定其他模板，生成可编辑 HTML 简历并提供 PDF 导出"
+      },
+      {
+        "name": "job-match",
+        "description": "岗位匹配：对照 JD 与真实经历生成证据矩阵和投递建议"
+      },
+      {
+        "name": "job-apply",
+        "description": "简历投递填写：通过已连接的浏览器填写申请并在提交前核对"
+      },
+      {
+        "name": "interview",
+        "description": "面试准备：简历驱动的面试问题预测与连续追问"
+      },
+      {
+        "name": "offer",
+        "description": "校招进度管理：记录投递、面试、offer 状态"
+      }
     ]
   },
   "install": {

--- a/.trae-plugin/plugin.json
+++ b/.trae-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "asu-skills",
-  "version": "0.3.0",
-  "description": "中文求职工作流：开源贡献、证据复盘、项目导学面经、简历提升、简历制作、岗位匹配、简历投递填写、面试准备和秋招进度管理。",
+  "version": "0.4.0",
   "author": {
     "name": "Hisn0w",
     "url": "https://github.com/Hisn00w"
@@ -9,15 +8,38 @@
   "homepage": "https://github.com/Hisn00w/ASu-skills",
   "repository": "https://github.com/Hisn00w/ASu-skills",
   "license": "MIT",
-  "keywords": ["resume", "interview", "job-search", "job-match", "job-application", "browser-automation", "career", "open-source", "contributor", "chinese", "great-resume", "evidence-recap"],
+  "keywords": [
+    "resume",
+    "job-search",
+    "job-match",
+    "job-application",
+    "browser-automation",
+    "career",
+    "open-source",
+    "chinese",
+    "project-analysis",
+    "contributor",
+    "evidence-recap",
+    "project-guide",
+    "great-resume",
+    "make-resume",
+    "job-apply",
+    "interview",
+    "offer"
+  ],
+  "description": "中文求职工作流：开源贡献、证据复盘、项目导学面经、简历提升、简历制作、岗位匹配、简历投递填写、面试准备和校招进度管理。",
   "skills": "./skills/",
   "interface": {
     "displayName": "ASu-skills",
     "shortDescription": "用 /contributor、/evidence-recap、/project-guide、/great-resume、/make-resume、/job-match、/job-apply、/interview、/offer 完成中文求职工作流",
-    "longDescription": "ASu-skills 将开源贡献、AI 编程对话复盘、项目导学面经、简历提升、中文简历制作、岗位匹配、简历投递填写、面试准备和秋招进度管理拆成九个可单独调用的 TraeWork skill，挂在同一个 asu-skills 插件下。",
+    "longDescription": "ASu-skills 将开源贡献、证据复盘、项目导学面经、简历提升、简历制作、岗位匹配、简历投递填写、面试准备和校招进度管理拆成九个可单独调用的 TraeWork skill，挂在同一个 asu-skills 插件下。",
     "developerName": "Hisn0w",
     "category": "Productivity",
-    "capabilities": ["Interactive", "Read", "Write"],
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
     "websiteURL": "https://github.com/Hisn00w/ASu-skills",
     "defaultPrompt": [
       "用 /contributor 寻找与目标岗位匹配的开源贡献机会。",

--- a/.workbuddy-plugin/install.md
+++ b/.workbuddy-plugin/install.md
@@ -2,7 +2,10 @@
 
 本目录提供**轻量安装脚本**，把 ASu-skills 原版 `skills/` 桥接到 WorkBuddy 的用户技能目录，**不修改原技能、不改动 LICENSE / README**。
 
-> 适用场景：WorkBuddy 用户想直接复用本仓库已有的 7 个中文求职技能（`contributor` / `evidence-recap` / `project-guide` / `great-resume` / `make-resume` / `interview` / `offer`），而无需等待完整移植。
+<!-- catalog:wb.md.intro:begin -->
+> 适用场景：WorkBuddy 用户想直接复用本仓库已有的 8 个可桥接中文求职技能（`contributor` / `evidence-recap` / `project-guide` / `great-resume` / `make-resume` / `job-match` / `interview` / `offer`），而无需等待完整移植。
+> 未纳入桥接：`job-apply`（依赖仓库根目录 scripts/ 下的 Kimi WebBridge 桥接脚本与浏览器扩展，纯技能目录桥接无法提供可执行环境）。
+<!-- catalog:wb.md.intro:end -->
 
 ## 前置条件
 
@@ -53,11 +56,13 @@ pwsh .workbuddy-plugin/install.ps1
 
 ### 方式三：手动复制
 
-把仓库 `skills/` 下的 7 个目录整体复制到 `~/.workbuddy/skills/`：
+<!-- catalog:wb.md.copy:begin -->
+把仓库 `skills/` 下可桥接的 8 个技能目录整体复制到 `~/.workbuddy/skills/`：
 
 ```bash
-cp -r skills/contributor skills/evidence-recap skills/project-guide skills/great-resume skills/make-resume skills/interview skills/offer "$HOME/.workbuddy/skills/"
+cp -r skills/contributor skills/evidence-recap skills/project-guide skills/great-resume skills/make-resume skills/job-match skills/interview skills/offer "$HOME/.workbuddy/skills/"
 ```
+<!-- catalog:wb.md.copy:end -->
 
 ## 验证
 
@@ -67,14 +72,13 @@ cp -r skills/contributor skills/evidence-recap skills/project-guide skills/great
 
 ## 卸载
 
+<!-- catalog:wb.md.uninstall:begin -->
 删除 `~/.workbuddy/skills/` 下对应的软链 / 目录即可：
 
 ```bash
-rm -rf "$HOME/.workbuddy/skills/contributor" "$HOME/.workbuddy/skills/evidence-recap" \
-       "$HOME/.workbuddy/skills/project-guide" "$HOME/.workbuddy/skills/great-resume" \
-       "$HOME/.workbuddy/skills/make-resume" \
-       "$HOME/.workbuddy/skills/interview" "$HOME/.workbuddy/skills/offer"
+rm -rf "$HOME/.workbuddy/skills/contributor" "$HOME/.workbuddy/skills/evidence-recap" "$HOME/.workbuddy/skills/project-guide" "$HOME/.workbuddy/skills/great-resume" "$HOME/.workbuddy/skills/make-resume" "$HOME/.workbuddy/skills/job-match" "$HOME/.workbuddy/skills/interview" "$HOME/.workbuddy/skills/offer"
 ```
+<!-- catalog:wb.md.uninstall:end -->
 
 ## 已知限制
 

--- a/.workbuddy-plugin/install.ps1
+++ b/.workbuddy-plugin/install.ps1
@@ -1,5 +1,7 @@
 # ASu-skills → WorkBuddy 轻量安装入口（Windows / PowerShell）
-# 把仓库原版 skills/ 下 8 个技能桥接到 $HOME/.workbuddy/skills/
+# catalog:wb.ps1.header:begin
+# 把仓库原版 skills/ 下可桥接的 8 个技能桥接到 $HOME/.workbuddy/skills/
+# catalog:wb.ps1.header:end
 # 优先软链；Windows 软链需开发者模式或管理员权限，失败则回退为复制。
 
 $ErrorActionPreference = 'Stop'
@@ -7,7 +9,9 @@ $ErrorActionPreference = 'Stop'
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 $src      = Join-Path $repoRoot 'skills'
 $dst      = Join-Path $env:USERPROFILE '.workbuddy\skills'
-$skills   = @('contributor', 'evidence-recap', 'project-guide', 'great-resume', 'make-resume', 'interview', 'offer')
+# catalog:wb.ps1.skills:begin
+$skills   = @('contributor', 'evidence-recap', 'project-guide', 'great-resume', 'make-resume', 'job-match', 'interview', 'offer')
+# catalog:wb.ps1.skills:end
 
 New-Item -ItemType Directory -Force -Path $dst | Out-Null
 
@@ -35,6 +39,8 @@ foreach ($s in $skills) {
     }
 }
 
+# catalog:wb.ps1.echo:begin
 Write-Host ""
 Write-Host "Done. 重启 WorkBuddy（或刷新技能列表）后即可触发："
-Write-Host "  contributor / evidence-recap / project-guide / great-resume / make-resume / interview / offer"
+Write-Host "  contributor / evidence-recap / project-guide / great-resume / make-resume / job-match / interview / offer"
+# catalog:wb.ps1.echo:end

--- a/.workbuddy-plugin/install.sh
+++ b/.workbuddy-plugin/install.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
+# catalog:wb.sh.header:begin
 # ASu-skills → WorkBuddy 轻量安装入口（macOS / Linux）
-# 把仓库原版 skills/ 下 8 个技能软链到 ~/.workbuddy/skills/
+# 把仓库原版 skills/ 下可桥接的 8 个技能软链到 ~/.workbuddy/skills/
+# catalog:wb.sh.header:end
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC="$REPO_ROOT/skills"
 DST="${HOME}/.workbuddy/skills"
-SKILLS=(contributor evidence-recap project-guide great-resume make-resume interview offer)
+# catalog:wb.sh.skills:begin
+SKILLS=(contributor evidence-recap project-guide great-resume make-resume job-match interview offer)
+# catalog:wb.sh.skills:end
 
 mkdir -p "$DST"
 
@@ -20,6 +24,8 @@ for s in "${SKILLS[@]}"; do
   fi
 done
 
+# catalog:wb.sh.echo:begin
 echo ""
 echo "Done. 重启 WorkBuddy（或刷新技能列表）后即可触发："
-echo "  contributor / evidence-recap / project-guide / great-resume / make-resume / interview / offer"
+echo "  contributor / evidence-recap / project-guide / great-resume / make-resume / job-match / interview / offer"
+# catalog:wb.sh.echo:end

--- a/README.md
+++ b/README.md
@@ -50,23 +50,25 @@
 - [开源协议](#开源协议)
 - [Star History](#star-history)
 
+<!-- catalog:readme.zh.intro:begin -->
 ASu-skills 现在是一个插件包。安装后会提供九个可单独调用的入口：
 
-| 入口               | 用途         | 主要交付                                                          |
-| ------------------ | ------------ | ----------------------------------------------------------------- |
-| `/contributor`   | 开源贡献     | 寻找候选、展示 diff，经确认后提交 PR并把贡献交给`/great-resume` |
-| `/evidence-recap` | 证据复盘     | 把 AI 编程对话和交付记录整理为可核验的九段证据链                  |
+| 入口 | 用途 | 主要交付 |
+| --- | --- | --- |
+| `/contributor` | 开源贡献 | 寻找候选、展示 diff，经确认后提交 PR并把贡献交给`/great-resume` |
+| `/evidence-recap` | 证据复盘 | 把 AI 编程对话和交付记录整理为可核验的九段证据链 |
 | `/project-guide` | 项目导学面经 | 基于项目仓库生成`导学-{简称}.md`、`面经-{简称}.md` 和交接摘要 |
-| `/great-resume`  | 简历提升     | 岗位定位、项目改写、成果证据、HR 开场白                           |
-| `/make-resume`   | 简历制作     | 默认使用 ASu 模板，也可指定模板；可编辑 HTML 简历和 PDF 导出       |
-| `/job-match`     | 岗位匹配     | 对照 JD 与真实经历，输出证据矩阵、硬性门槛和投递建议              |
-| `/job-apply`     | 简历投递填写 | 连接浏览器自动填写求职申请，核对后停在提交前                      |
-| `/interview`     | 面试准备     | 面试预测、契约化追问、证据复盘和弱项复练                          |
-| `/offer`         | 校招进度     | 投递、测评、面试、Offer、拒信和招聘邮件跟踪                       |
+| `/great-resume` | 简历提升 | 岗位定位、项目改写、成果证据、HR 开场白 |
+| `/make-resume` | 简历制作 | 默认使用 ASu 模板，也可指定模板；可编辑 HTML 简历和 PDF 导出 |
+| `/job-match` | 岗位匹配 | 对照 JD 与真实经历，输出证据矩阵、硬性门槛和投递建议 |
+| `/job-apply` | 简历投递填写 | 连接浏览器自动填写求职申请，核对后停在提交前 |
+| `/interview` | 面试准备 | 面试预测、契约化追问、证据复盘和弱项复练 |
+| `/offer` | 校招进度管理 | 投递、测评、面试、Offer、拒信和招聘邮件跟踪 |
+<!-- catalog:readme.zh.intro:end -->
 
 ## 安装
 
-ASu-skills 同时支持 Codex、Claude Code 和 TraeWork：仓库根目录的 `.codex-plugin/` 供 Codex 使用，`.claude-plugin/` 供 Claude Code 使用，`.trae-plugin/` 供 TraeWork 使用，三者共用同一套 `skills/`、`assets/` 和 `references/`。
+ASu-skills 同时支持 Codex、Claude Code 和 TraeWork，另有 OpenCode 与 WorkBuddy 的轻量桥接入口：仓库根目录的 `.codex-plugin/` 供 Codex 使用，`.claude-plugin/` 供 Claude Code 使用，`.trae-plugin/` 供 TraeWork 使用，`.opencode-plugin/`、`.workbuddy-plugin/` 提供社区安装入口；所有入口共用同一套 `skills/`、`assets/` 和 `references/`。入口清单以根目录 `skills.registry.json` 为单一事实源，由 `npm run sync:skills` 生成并对账（CI 以 `--check` 校验）。
 
 ### Codex
 
@@ -386,49 +388,39 @@ asu-skills/
 │   ├── plugin.json              # Claude Code 插件清单
 │   └── marketplace.json         # Claude Code 插件市场清单
 ├── .codex-plugin/
-│   └── plugin.json              # 插件清单
+│   └── plugin.json              # Codex 插件清单
 ├── .trae-plugin/
 │   └── plugin.json              # TraeWork 插件清单
+├── .opencode-plugin/
+│   ├── plugin.json              # OpenCode 插件清单（skills.entries 由 registry 生成）
+│   ├── install-opencode.py      # OpenCode 安装脚本（技能名单由 registry 生成）
+│   └── installation-guide.md    # OpenCode 手动安装指南
+├── .workbuddy-plugin/
+│   ├── install.md               # WorkBuddy 桥接说明（清单区由 registry 生成）
+│   ├── install.sh               # macOS / Linux 桥接脚本
+│   └── install.ps1              # Windows 桥接脚本
+├── skills.registry.json        # ★ 入口目录单一事实源：新增/删除入口先改这里，再 npm run sync:skills
 ├── package.json                # DSH 插件包清单（bundle patch 入口）
 ├── cordis.patch.yml            # 注册 DSH filesystem skill 提供方
 ├── lib/
 │   └── index.js                # DSH 插件入口模块
-├── skills/
-│   ├── great-resume/
-│   │   ├── SKILL.md             # /great-resume 简历提升
-│   │   └── agents/openai.yaml
-│   ├── contributor/
-│   │   ├── SKILL.md             # /contributor 开源贡献
-│   │   └── agents/openai.yaml
-│   ├── evidence-recap/
-│   │   ├── SKILL.md             # /evidence-recap AI 编程对话复盘
-│   │   └── agents/openai.yaml
-│   ├── project-guide/
-│   │   ├── SKILL.md             # /project-guide 项目导学面经
-│   │   └── agents/openai.yaml
-│   ├── make-resume/
-│   │   ├── SKILL.md             # /make-resume 简历制作
-│   │   └── agents/openai.yaml
-│   ├── job-match/
-│   │   ├── SKILL.md             # /job-match 岗位匹配分析
-│   │   └── agents/openai.yaml
-│   ├── interview/
-│   │   ├── SKILL.md             # /interview 面试预测、追问与复练
-│   │   ├── references/          # 面试契约、评分、场景题和复练规则
-│   │   └── agents/openai.yaml
-│   ├── offer/
-│       ├── SKILL.md             # /offer 校招进度
-│       └── agents/openai.yaml
-│   └── job-apply/
-│       ├── SKILL.md             # /job-apply 简历投递填写
-│       ├── references/           # Kimi WebBridge 连接与安全规则
-│       └── agents/openai.yaml
+├── skills/                     # 全部入口目录（与 skills.registry.json 一一对应）
+│   ├── contributor/            # /contributor 开源贡献
+│   ├── evidence-recap/         # /evidence-recap AI 编程对话复盘
+│   ├── great-resume/           # /great-resume 简历提升
+│   ├── interview/              # /interview 面试预测、追问与复练
+│   ├── job-apply/              # /job-apply 简历投递填写（依赖浏览器桥接）
+│   ├── job-match/              # /job-match 岗位匹配分析
+│   ├── make-resume/            # /make-resume 简历制作
+│   ├── offer/                  # /offer 校招进度管理
+│   └── project-guide/          # /project-guide 项目导学面经
 ├── scripts/
-│   └── kimi-webbridge.mjs       # Kimi WebBridge 本机 HTTP 客户端
-├── assets/                      # 模板、图片、进度表和示例资源
+│   ├── sync-skill-catalog.mjs  # ★ 从 registry 生成/对账各入口清单（npm run sync:skills）
+│   └── kimi-webbridge.mjs      # Kimi WebBridge 本机 HTTP 客户端
+├── assets/                     # 模板、图片、进度表和示例资源
 │   ├── asu-resume-template.html # ASu 同款可编辑简历起点
-│   ├── icons/                    # 个人信息与通用信息 SVG 图标
-│   └── logos/                    # LobeHub Icons 静态 SVG Logo
+│   ├── icons/                   # 个人信息与通用信息 SVG 图标
+│   └── logos/                   # LobeHub Icons 静态 SVG Logo
 ├── references/                  # 招聘邮箱整理参考
 ├── .github/
 │   ├── CONTRIBUTING.md          # 贡献指南
@@ -440,6 +432,8 @@ asu-skills/
 ## 参与贡献
 
 欢迎提 Issue 和 PR，详见[贡献指南](.github/CONTRIBUTING.md)。也可以直接查看 [Pull Requests](https://github.com/Hisn00w/ASu-skills/pulls)。
+
+新增、删除或重命名入口时，先更新 [`skills.registry.json`](skills.registry.json)，再运行 `npm run sync:skills` 同步全部插件清单、安装脚本、Issue 模板与 README 总览；CI 会以 `npm run sync:skills -- --check` 校验一致性。
 
 ## 致谢
 

--- a/README_en.md
+++ b/README_en.md
@@ -62,23 +62,25 @@ ASu is building a Harness project tailored to the job-search journey. We welcome
 
 [Check out the ASu Harness project on GitHub](https://github.com/Hisn00w/ASu-skills)
 
+<!-- catalog:readme.en.intro:begin -->
 ASu-skills is now a plugin pack. Installing it provides nine individually callable entry points:
 
-| Entry          | Purpose                   | Primary deliverables                                              |
-| -------------- | ------------------------ | ----------------------------------------------------------------- |
+| Entry | Purpose | Primary deliverables |
+| --- | --- | --- |
 | `/contributor` | Open-source contributions | Finds candidates, shows diffs, submits a PR after your confirmation, and hands the contribution to `/great-resume` |
-| `/evidence-recap` | Conversation review      | Turns AI coding conversations and delivery records into a verifiable nine-part evidence chain |
+| `/evidence-recap` | Conversation review | Turns AI coding conversations and delivery records into a verifiable nine-part evidence chain |
 | `/project-guide` | Project interview prep | Generates `导学-{short-name}.md`, `面经-{short-name}.md`, and handoff evidence from a project repository |
-| `/great-resume` | Resume improvement       | Role targeting, project bullet rewrites, evidence of results, HR opener |
-| `/make-resume`      | Resume building          | Defaults to the ASu template, supports custom templates, editable HTML resume and PDF export |
-| `/job-match`   | Job matching | Compares a JD with verified experience and returns an evidence matrix, hard constraints, and an application recommendation |
-| `/job-apply`   | Job-application autofill | Connects to a browser, fills an application, and stops for review before submission |
-| `/interview`   | Interview preparation    | Interview prediction, contract-driven drilling, evidence review, and targeted retry |
-| `/offer`       | Campus recruitment tracking | Tracks applications, assessments, interviews, offers, rejections, and recruiting emails |
+| `/great-resume` | Resume improvement | Role targeting, project bullet rewrites, evidence of results, HR opener |
+| `/make-resume` | Resume building | Defaults to the ASu template, supports custom templates, editable HTML resume and PDF export |
+| `/job-match` | Job matching | Compares a JD with verified experience and returns an evidence matrix, hard constraints, and an application recommendation |
+| `/job-apply` | Job-application autofill | Connects to a browser, fills an application, and stops for review before submission |
+| `/interview` | Interview preparation | Interview prediction, contract-driven drilling, evidence review, and targeted retry |
+| `/offer` | Campus recruitment tracking | Tracks applications, assessments, interviews, offers, rejections, and recruiting emails |
+<!-- catalog:readme.en.intro:end -->
 
 ## Installation
 
-ASu-skills works with Codex, Claude Code, and TraeWork: the repo root has `.codex-plugin/` for Codex, `.claude-plugin/` for Claude Code, and `.trae-plugin/` for TraeWork, all sharing the same `skills/`, `assets/`, and `references/`.
+ASu-skills works with Codex, Claude Code, and TraeWork, plus lightweight OpenCode and WorkBuddy bridges: the repo root has `.codex-plugin/` for Codex, `.claude-plugin/` for Claude Code, `.trae-plugin/` for TraeWork, and `.opencode-plugin/`/`.workbuddy-plugin/` for community installers — all sharing the same `skills/`, `assets/`, and `references/`. The entry catalog is maintained in `skills.registry.json` as the single source of truth and is regenerated/reconciled by `npm run sync:skills` (CI checks it with `--check`).
 
 ### Codex
 
@@ -401,46 +403,36 @@ asu-skills/
 │   ├── plugin.json              # Claude Code plugin manifest
 │   └── marketplace.json         # Claude Code plugin marketplace manifest
 ├── .codex-plugin/
-│   └── plugin.json              # Plugin manifest
+│   └── plugin.json              # Codex plugin manifest
 ├── .trae-plugin/
 │   └── plugin.json              # TraeWork plugin manifest
-├── package.json                 # DSH plugin pack manifest (bundle patch entry)
-├── cordis.patch.yml             # Registers the DSH filesystem skill provider
+├── .opencode-plugin/
+│   ├── plugin.json              # OpenCode plugin manifest (skills.entries generated from the registry)
+│   ├── install-opencode.py      # OpenCode installer (skill list generated from the registry)
+│   └── installation-guide.md    # OpenCode manual installation guide
+├── .workbuddy-plugin/
+│   ├── install.md               # WorkBuddy bridge guide (catalog blocks generated from the registry)
+│   ├── install.sh               # macOS / Linux bridge script
+│   └── install.ps1              # Windows bridge script
+├── skills.registry.json        # ★ Single source of truth for the entry catalog; run npm run sync:skills after changing it
+├── package.json                # DSH plugin pack manifest (bundle patch entry)
+├── cordis.patch.yml            # Registers the DSH filesystem skill provider
 ├── lib/
-│   └── index.js                 # DSH plugin entry module
-├── skills/
-│   ├── great-resume/
-│   │   ├── SKILL.md             # /great-resume experience improvement
-│   │   └── agents/openai.yaml
-│   ├── contributor/
-│   │   ├── SKILL.md             # /contributor open-source contributions
-│   │   └── agents/openai.yaml
-│   ├── evidence-recap/
-│   │   ├── SKILL.md             # /evidence-recap AI coding conversation review
-│   │   └── agents/openai.yaml
-│   ├── project-guide/
-│   │   ├── SKILL.md             # /project-guide project study notes and interview answers
-│   │   └── agents/openai.yaml
-│   ├── make-resume/
-│   │   ├── SKILL.md             # /make-resume resume building
-│   │   └── agents/openai.yaml
-│   ├── job-match/
-│   │   ├── SKILL.md             # /job-match job-match analysis
-│   │   └── agents/openai.yaml
-│   ├── interview/
-│   │   ├── SKILL.md             # /interview prediction, drilling & targeted retry
-│   │   ├── references/          # Interview contracts, scoring, scenarios & retry rules
-│   │   └── agents/openai.yaml
-│   ├── offer/
-│       ├── SKILL.md             # /offer campus recruitment tracking
-│       └── agents/openai.yaml
-│   └── job-apply/
-│       ├── SKILL.md             # /job-apply job-application autofill
-│       ├── references/          # Kimi WebBridge connection and safety rules
-│       └── agents/openai.yaml
+│   └── index.js                # DSH plugin entry module
+├── skills/                     # Every entry directory (one-to-one with skills.registry.json)
+│   ├── contributor/            # /contributor open-source contributions
+│   ├── evidence-recap/         # /evidence-recap AI coding conversation review
+│   ├── great-resume/           # /great-resume resume improvement
+│   ├── interview/              # /interview prediction, drilling & targeted retry
+│   ├── job-apply/              # /job-apply job-application autofill (browser bridge)
+│   ├── job-match/              # /job-match job-match analysis
+│   ├── make-resume/            # /make-resume resume building
+│   ├── offer/                  # /offer campus recruitment tracking
+│   └── project-guide/          # /project-guide project study notes and interview answers
 ├── scripts/
-│   └── kimi-webbridge.mjs       # Kimi WebBridge local HTTP client
-├── assets/                      # Templates, images, tracker, and example resources
+│   ├── sync-skill-catalog.mjs  # ★ Generates/reconciles every entry catalog from the registry (npm run sync:skills)
+│   └── kimi-webbridge.mjs      # Kimi WebBridge local HTTP client
+├── assets/                     # Templates, images, tracker, and example resources
 │   ├── asu-resume-template.html # Read-only master for the ASu-style editable resume
 │   ├── icons/                   # Personal & general information SVG icons
 │   └── logos/                   # LobeHub Icons static SVG logos
@@ -455,6 +447,8 @@ asu-skills/
 ## Contributing
 
 Issues and PRs are welcome. See the [contributing guide](.github/CONTRIBUTING_en.md), or browse the repository's [Pull Requests](https://github.com/Hisn00w/ASu-skills/pulls).
+
+When adding, removing, or renaming an entry, first update [`skills.registry.json`](skills.registry.json), then run `npm run sync:skills` to regenerate every plugin manifest, installer, issue template, and the README overview; CI verifies consistency with `npm run sync:skills -- --check`.
 
 ## Acknowledgments
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "export:pdf": "node scripts/export-resume-pdf.mjs",
     "build:templates": "node scripts/inline-template.mjs --all dist/templates",
+    "sync:skills": "node scripts/sync-skill-catalog.mjs",
+    "sync:skills:check": "node scripts/sync-skill-catalog.mjs --check",
     "validate:skills": "python3 scripts/validate_skills.py",
     "test:python": "python3 -m unittest discover -s tests -v",
     "test": "node --test"
@@ -30,9 +32,6 @@
     "dsh-plugin",
     "deepseek-harness",
     "agent-skill",
-    "evidence-recap",
-    "project-guide",
-    "project-analysis",
     "resume",
     "job-search",
     "job-match",
@@ -41,7 +40,15 @@
     "career",
     "open-source",
     "chinese",
-    "great-resume"
+    "project-analysis",
+    "contributor",
+    "evidence-recap",
+    "project-guide",
+    "great-resume",
+    "make-resume",
+    "job-apply",
+    "interview",
+    "offer"
   ],
   "engines": {
     "node": "^22.19.0 || >=24.0.0"

--- a/scripts/sync-skill-catalog.mjs
+++ b/scripts/sync-skill-catalog.mjs
@@ -1,0 +1,293 @@
+// @ts-check
+/**
+ * ASu-skills 入口目录同步器（单一事实源 = skills.registry.json）
+ *
+ * 用法：
+ *   node scripts/sync-skill-catalog.mjs            # 生成全部派生文件/字段
+ *   node scripts/sync-skill-catalog.mjs --check    # 只对账，不写盘；不一致时退出码 1
+ *
+ * 由 skills.registry.json 生成：
+ *   - .codex-plugin/plugin.json / .trae-plugin/plugin.json
+ *   - .claude-plugin/plugin.json / .claude-plugin/marketplace.json
+ *   - .opencode-plugin/plugin.json（skills.entries + 描述字段）
+ *   - package.json 的 keywords
+ *   - .opencode-plugin/install-opencode.py 的 SKILL_NAMES 与触发词输出
+ *   - .workbuddy-plugin/install.sh / install.ps1 的技能数组、数量文案与输出
+ *   - .workbuddy-plugin/install.md 的目录清单区
+ *   - README.md / README_en.md 的入口总览区
+ *   - .github/ISSUE_TEMPLATE/*.yml 的“相关技能”选项
+ */
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const CHECK = process.argv.includes('--check');
+const NL = '\n';
+
+// ------------------------------------------------ utils
+const zhNum = (n) => (n >= 1 && n <= 9 ? '零一二三四五六七八九'[n] : String(n));
+const enNum = (n) => (['zero','one','two','three','four','five','six','seven','eight','nine','ten','eleven','twelve'][n] ?? String(n));
+const joinCn = (list) => (list.length <= 1 ? list.join('') : list.slice(0, -1).join('、') + '和' + list[list.length - 1]);
+const uniq = (xs) => [...new Set(xs)];
+const json = (obj) => JSON.stringify(obj, null, 2) + '\n';
+
+function withRegion(text, id, kind, body) {
+  const open = kind === 'html' ? '<!-- catalog:' + id + ':begin -->' : '# catalog:' + id + ':begin';
+  const close = kind === 'html' ? '<!-- catalog:' + id + ':end -->' : '# catalog:' + id + ':end';
+  const ib = text.indexOf(open);
+  if (ib < 0) throw new Error('region marker not found: ' + open);
+  const ie = text.indexOf(close);
+  if (ie < ib) throw new Error('region end marker not found or misplaced: ' + close);
+  const lineStart = text.lastIndexOf(NL, ib) + 1;
+  const newlineAt = text.indexOf(NL, ie);
+  const lineEnd = newlineAt === -1 ? text.length : newlineAt;
+  const block = open + NL + body + NL + close;
+  const tail = text.slice(lineEnd + 1);
+  return text.slice(0, lineStart) + block + NL + tail;
+}
+function read(rel) { return readFileSync(join(ROOT, rel), 'utf8'); }
+function write(rel, text) { writeFileSync(join(ROOT, rel), text.endsWith(NL) ? text : text + NL); }
+
+// ------------------------------------------------ inputs
+const registry = JSON.parse(read('skills.registry.json'));
+const pkg = JSON.parse(read('package.json'));
+const version = pkg.version;
+const entries = registry.entries;
+const names = entries.map((e) => e.name);
+const slashList = names.map((n) => '/' + n).join('、');
+const fnList = joinCn(entries.map((e) => e.zh.menuLabel));
+const prompts = entries.map((e) => e.zh.prompt);
+const keywords = uniq([...registry.keywordsBase, ...names]);
+const workbuddy = entries.filter((e) => !e.excludeFrom || !e.excludeFrom.workbuddy);
+const wbNames = workbuddy.map((e) => e.name);
+
+const changes = [];
+function stage(label, current, next) { if (current !== next) changes.push(label); return next; }
+
+// ------------------------------------------------ JSON manifests
+const common = {
+  name: registry.name,
+  version,
+  author: registry.author,
+  homepage: registry.homepage,
+  repository: registry.repository,
+  license: registry.license,
+  keywords,
+};
+
+const codex = {
+  ...common,
+  description: '中文求职工作流：' + fnList + '。',
+  skills: './skills/',
+  interface: {
+    displayName: registry.displayName,
+    shortDescription: '用 ' + slashList + ' 完成中文求职工作流',
+    longDescription: 'ASu-skills 将' + fnList + '拆成' + zhNum(entries.length) + '个可单独调用的 Codex skill。',
+    developerName: registry.developerName,
+    category: registry.category,
+    capabilities: ['Interactive', 'Write'],
+    websiteURL: registry.websiteURL,
+    defaultPrompt: prompts,
+    brandColor: registry.brandColor,
+    composerIcon: registry.composerIcon,
+    logo: registry.logo,
+  },
+};
+
+const trae = {
+  ...common,
+  description: '中文求职工作流：' + fnList + '。',
+  skills: './skills/',
+  interface: {
+    displayName: registry.displayName,
+    shortDescription: '用 ' + slashList + ' 完成中文求职工作流',
+    longDescription: 'ASu-skills 将' + fnList + '拆成' + zhNum(entries.length) + '个可单独调用的 TraeWork skill，挂在同一个 asu-skills 插件下。',
+    developerName: registry.developerName,
+    category: registry.category,
+    capabilities: ['Interactive', 'Read', 'Write'],
+    websiteURL: registry.websiteURL,
+    defaultPrompt: prompts,
+    brandColor: registry.brandColor,
+    composerIcon: registry.composerIcon,
+    logo: registry.logo,
+  },
+};
+
+const claude = {
+  name: registry.name,
+  displayName: registry.displayName,
+  description: '中文求职工作流：' + fnList + '。',
+  ...common,
+};
+
+const marketplace = {
+  name: 'asu',
+  description: 'ASu 中文求职工作流插件市场。',
+  owner: { name: registry.author.name, url: registry.author.url },
+  plugins: [{
+    ...common,
+    name: registry.name,
+    source: './',
+    displayName: registry.displayName,
+    description: '用 ' + slashList + ' 完成中文求职工作流。',
+    category: registry.category,
+  }],
+};
+
+const opencodeInstall = {
+  method: 'copy',
+  source: 'skills',
+  destination: '{opencode_skills_dir}',
+  instructions: {
+    zh: registry.snippets.opencodeInstructionsZh,
+    en: registry.snippets.opencodeInstructionsEn,
+  },
+};
+
+const opencode = {
+  ...common,
+  description: '中文求职工作流插件：' + fnList + '。',
+  skills: {
+    path: './skills',
+    entries: entries.map((e) => ({ name: e.name, description: e.zh.menuLabel + '：' + e.zh.opencodeDetail })),
+  },
+  install: opencodeInstall,
+};
+
+const pkgKeywords = uniq(['dsh-plugin', 'deepseek-harness', 'agent-skill', ...keywords]);
+const nextPkg = { ...pkg, keywords: pkgKeywords };
+
+// ------------------------------------------------ content builders
+function readmeBlock(lang) {
+  const zh = lang === 'zh';
+  const head = zh
+    ? 'ASu-skills 现在是一个插件包。安装后会提供' + zhNum(entries.length) + '个可单独调用的入口：'
+    : 'ASu-skills is now a plugin pack. Installing it provides ' + enNum(entries.length) + ' individually callable entry points:';
+  const header = zh ? '| 入口 | 用途 | 主要交付 |' : '| Entry | Purpose | Primary deliverables |';
+  const sep = '| --- | --- | --- |';
+  const rows = entries.map((e) => {
+    const cols = zh
+      ? ['`/' + e.name + '`', e.zh.menuLabel, e.zh.deliverables]
+      : ['`/' + e.name + '`', e.en.menu, e.en.deliverables];
+    return '| ' + cols.join(' | ') + ' |';
+  });
+  return [head, '', header, sep].concat(rows).join(NL);
+}
+
+function wbIntro() {
+  const listed = wbNames.map((n) => '`' + n + '`').join(' / ');
+  const lines = ['> 适用场景：WorkBuddy 用户想直接复用本仓库已有的 ' + wbNames.length + ' 个可桥接中文求职技能（' + listed + '），而无需等待完整移植。'];
+  for (const e of workbuddy.length === 0 ? [] : entries.filter((x) => x.excludeFrom && x.excludeFrom.workbuddy)) {
+    lines.push('> 未纳入桥接：`' + e.name + '`（' + e.excludeFrom.workbuddy + '）。');
+  }
+  return lines.join(NL);
+}
+
+function wbCopy() {
+  const namesArg = wbNames.map((n) => 'skills/' + n).join(' ');
+  return [
+    '把仓库 `skills/` 下可桥接的 ' + wbNames.length + ' 个技能目录整体复制到 `~/.workbuddy/skills/`：',
+    '',
+    '```bash',
+    'cp -r ' + namesArg + ' "$HOME/.workbuddy/skills/"',
+    '```',
+  ].join(NL);
+}
+
+function wbUninstall() {
+  const items = wbNames.map((n) => '"$HOME/.workbuddy/skills/' + n + '"');
+  return [
+    '删除 `~/.workbuddy/skills/` 下对应的软链 / 目录即可：',
+    '',
+    '```bash',
+    'rm -rf ' + items.join(' '),
+    '```',
+  ].join(NL);
+}
+
+const wbEchoTail = '  ' + wbNames.join(' / ');
+const pySkillTuple = ['SKILL_NAMES = ('].concat(names.map((n) => '    "' + n + '",'), [')']).join(NL);
+const pyEcho = 'TRIGGER_WORDS = "' + names.map((n) => '/' + n).join('  ') + '"';
+
+const regionTargets = [
+  { rel: '.opencode-plugin/install-opencode.py', kind: 'hash', id: 'opencode.skills', body: pySkillTuple },
+  { rel: '.opencode-plugin/install-opencode.py', kind: 'hash', id: 'opencode.echo', body: pyEcho },
+  { rel: '.workbuddy-plugin/install.sh', kind: 'hash', id: 'wb.sh.header', body: ['# ASu-skills → WorkBuddy 轻量安装入口（macOS / Linux）', '# 把仓库原版 skills/ 下可桥接的 ' + wbNames.length + ' 个技能软链到 ~/.workbuddy/skills/'].join(NL) },
+  { rel: '.workbuddy-plugin/install.sh', kind: 'hash', id: 'wb.sh.skills', body: 'SKILLS=(' + wbNames.join(' ') + ')' },
+  { rel: '.workbuddy-plugin/install.sh', kind: 'hash', id: 'wb.sh.echo', body: ['echo ""', 'echo "Done. 重启 WorkBuddy（或刷新技能列表）后即可触发："', 'echo "' + wbEchoTail + '"'].join(NL) },
+  { rel: '.workbuddy-plugin/install.ps1', kind: 'hash', id: 'wb.ps1.header', body: '# 把仓库原版 skills/ 下可桥接的 ' + wbNames.length + ' 个技能桥接到 $HOME/.workbuddy/skills/' },
+  { rel: '.workbuddy-plugin/install.ps1', kind: 'hash', id: 'wb.ps1.skills', body: "$skills   = @('" + wbNames.join("', '") + "')" },
+  { rel: '.workbuddy-plugin/install.ps1', kind: 'hash', id: 'wb.ps1.echo', body: ['Write-Host ""', 'Write-Host "Done. 重启 WorkBuddy（或刷新技能列表）后即可触发："', 'Write-Host "' + wbEchoTail + '"'].join(NL) },
+  { rel: '.workbuddy-plugin/install.md', kind: 'html', id: 'wb.md.intro', body: wbIntro() },
+  { rel: '.workbuddy-plugin/install.md', kind: 'html', id: 'wb.md.copy', body: wbCopy() },
+  { rel: '.workbuddy-plugin/install.md', kind: 'html', id: 'wb.md.uninstall', body: wbUninstall() },
+  { rel: 'README.md', kind: 'html', id: 'readme.zh.intro', body: readmeBlock('zh') },
+  { rel: 'README_en.md', kind: 'html', id: 'readme.en.intro', body: readmeBlock('en') },
+  { rel: '.github/ISSUE_TEMPLATE/bug_report.yml', kind: 'hash', id: 'issue.bug.options', body: entries.map((e) => '        - /' + e.name + ' ' + e.zh.menuLabel).join(NL) },
+  { rel: '.github/ISSUE_TEMPLATE/feature_request.yml', kind: 'hash', id: 'issue.feature.options', body: entries.map((e) => '        - /' + e.name + ' ' + e.zh.menuLabel).join(NL) },
+];
+
+// ------------------------------------------------ cross-checks (before any write)
+const skillDirs = readdirSync(join(ROOT, 'skills'), { withFileTypes: true })
+  .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+  .map((d) => d.name)
+  .sort();
+const sortedNames = [...names].sort();
+const problems = [];
+if (JSON.stringify(skillDirs) !== JSON.stringify(sortedNames)) {
+  problems.push('skills/ 目录与 registry 不一致：目录多出=' + skillDirs.filter((n) => !sortedNames.includes(n)).join(',') + '；registry 多出=' + sortedNames.filter((n) => !skillDirs.includes(n)).join(','));
+}
+const seen = new Set();
+for (const e of entries) {
+  if (seen.has(e.name)) problems.push('registry 存在重复入口: ' + e.name);
+  seen.add(e.name);
+  for (const field of ['zh.menuLabel', 'zh.prompt', 'zh.opencodeDetail', 'zh.deliverables', 'en.menu', 'en.deliverables']) {
+    const [a, b] = field.split('.');
+    if (!e[a] || typeof e[a][b] !== 'string' || !e[a][b].trim()) problems.push('entry ' + e.name + ' 缺少 ' + field);
+  }
+  if (e.excludeFrom && !Object.keys(e.excludeFrom).every((h) => h === 'workbuddy')) problems.push('entry ' + e.name + ' 的 excludeFrom 含未知宿主');
+}
+for (const t of regionTargets) {
+  const text = read(t.rel);
+  const token = t.kind === 'html' ? '<!-- catalog:' + t.id + ':begin -->' : '# catalog:' + t.id + ':begin';
+  if (!text.includes(token)) problems.push('缺少 catalog 标记: ' + t.rel + ' [' + t.id + ']（请先运行一次手动补标记或检查文件）');
+}
+if (problems.length) {
+  console.error('skill catalog problems:');
+  for (const p of problems) console.error('  - ' + p);
+  process.exit(1);
+}
+
+// ------------------------------------------------ write or stage
+const fileTargets = [
+  ['.codex-plugin/plugin.json', json(codex)],
+  ['.trae-plugin/plugin.json', json(trae)],
+  ['.claude-plugin/plugin.json', json(claude)],
+  ['.claude-plugin/marketplace.json', json(marketplace)],
+  ['.opencode-plugin/plugin.json', json(opencode)],
+  ['package.json', json(nextPkg)],
+];
+for (const [rel, next] of fileTargets) stage(rel, read(rel), next);
+for (const t of regionTargets) {
+  const text = read(t.rel);
+  stage(t.rel, text, withRegion(text, t.id, t.kind, t.body));
+}
+
+if (changes.length) {
+  if (CHECK) {
+    console.error('skill catalog drift detected:');
+    for (const c of changes) console.error('  - ' + c);
+    console.error('请运行 node scripts/sync-skill-catalog.mjs 后重新提交。');
+    process.exit(1);
+  }
+  for (const [rel, next] of fileTargets) write(rel, next);
+  for (const t of regionTargets) {
+    const text = read(t.rel);
+    write(t.rel, withRegion(text, t.id, t.kind, t.body));
+  }
+  console.log('synced ' + changes.length + ' target(s):');
+  for (const c of changes) console.log('  - ' + c);
+} else {
+  console.log('skill catalog sync OK (' + entries.length + ' entries, nothing to change)');
+}

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -40,6 +40,7 @@ TRAE_PLUGIN_MANIFEST = REPO_ROOT / ".trae-plugin" / "plugin.json"
 CLAUDE_PLUGIN_MANIFEST = REPO_ROOT / ".claude-plugin" / "plugin.json"
 CLAUDE_MARKETPLACE_MANIFEST = REPO_ROOT / ".claude-plugin" / "marketplace.json"
 OPENCODE_PLUGIN_MANIFEST = REPO_ROOT / ".opencode-plugin" / "plugin.json"
+REGISTRY_MANIFEST = REPO_ROOT / "skills.registry.json"
 
 DESCRIPTION_MAX_LEN = 500
 
@@ -588,6 +589,53 @@ def check_opencode_manifest(skill_dirs: List[Path], report: Report) -> None:
         report.add(True, "", f"{label} skills.entries 覆盖全部 skill")
 
 
+def check_registry(skill_dirs: List[Path], report: Report) -> None:
+    """校验 skills.registry.json：入口名唯一、必备字段齐全、与 skills/ 目录一一对应。"""
+    label = "skills.registry.json"
+    manifest = read_json_manifest(REGISTRY_MANIFEST, label, report)
+    if manifest is None:
+        return
+    if not isinstance(manifest, dict):
+        report.add(False, "", f"{label} 顶层不是对象")
+        return
+    entries = manifest.get("entries")
+    if not isinstance(entries, list) or not entries:
+        report.add(False, "", f"{label} 缺少非空 entries 列表")
+        return
+    seen = set()
+    actual: set = set()
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            report.add(False, "", f"{label} entries[{index}] 不是对象")
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            report.add(False, "", f"{label} entries[{index}] 缺少 name")
+            continue
+        if name in seen:
+            report.add(False, "", f"{label} 重复入口: {name}")
+        seen.add(name)
+        actual.add(name)
+        zh = entry.get("zh")
+        en = entry.get("en")
+        for field in ("menuLabel", "prompt", "opencodeDetail", "deliverables"):
+            value = (zh or {}).get(field) if isinstance(zh, dict) else None
+            if not isinstance(value, str) or not value.strip():
+                report.add(False, "", f"{label} 入口 {name} 缺少 zh.{field}")
+        for field in ("menu", "deliverables"):
+            value = (en or {}).get(field) if isinstance(en, dict) else None
+            if not isinstance(value, str) or not value.strip():
+                report.add(False, "", f"{label} 入口 {name} 缺少 en.{field}")
+    expected = {d.name for d in skill_dirs}
+    if expected != actual:
+        report.add(
+            False,
+            "",
+            f"{label} 与 skills/ 目录不一致：registry 多出={sorted(actual - expected)}，目录多出={sorted(expected - actual)}",
+        )
+    else:
+        report.add(True, "", f"{label} 覆盖全部 {len(actual)} 个 skill")
+
 def check_templates(report: Report) -> None:
     """校验 assets/templates-html/ 的外框解耦结构。
 
@@ -653,6 +701,7 @@ def main() -> int:
         report,
     )
     check_opencode_manifest(skill_dirs, report)
+    check_registry(skill_dirs, report)
     check_templates(report)
 
     print(report.summary())

--- a/skills.registry.json
+++ b/skills.registry.json
@@ -1,0 +1,165 @@
+{
+  "comment": "ASu-skills 入口目录单一事实源。新增/删除/改名入口时：1) 在 skills/ 下建/删目录；2) 编辑本文件 entries；3) 在仓库根目录运行 `npm run sync:skills`；4) 涉及新入口的 README/SKILL.md 文案自行补充。不要手工编辑由 sync 生成的字段/文件。",
+  "name": "asu-skills",
+  "displayName": "ASu-skills",
+  "developerName": "Hisn0w",
+  "category": "Productivity",
+  "brandColor": "#11A683",
+  "composerIcon": "./assets/asu-circle.png",
+  "logo": "./assets/asu-circle.png",
+  "websiteURL": "https://github.com/Hisn00w/ASu-skills",
+  "homepage": "https://github.com/Hisn00w/ASu-skills",
+  "repository": "https://github.com/Hisn00w/ASu-skills",
+  "license": "MIT",
+  "author": {
+    "name": "Hisn0w",
+    "url": "https://github.com/Hisn00w"
+  },
+  "keywordsBase": [
+    "resume",
+    "job-search",
+    "job-match",
+    "job-application",
+    "browser-automation",
+    "career",
+    "open-source",
+    "chinese",
+    "project-analysis"
+  ],
+  "entries": [
+    {
+      "name": "contributor",
+      "zh": {
+        "menuLabel": "开源贡献",
+        "prompt": "用 /contributor 寻找与目标岗位匹配的开源贡献机会。",
+        "opencodeDetail": "寻找目标岗位匹配的开源贡献机会",
+        "deliverables": "寻找候选、展示 diff，经确认后提交 PR并把贡献交给`/great-resume`"
+      },
+      "en": {
+        "menu": "Open-source contributions",
+        "deliverables": "Finds candidates, shows diffs, submits a PR after your confirmation, and hands the contribution to `/great-resume`"
+      }
+    },
+    {
+      "name": "evidence-recap",
+      "zh": {
+        "menuLabel": "证据复盘",
+        "prompt": "用 /evidence-recap 把 AI 编程对话和交付记录整理为可核验的项目证据链。",
+        "opencodeDetail": "把 AI 编程对话和交付记录整理为可核验的项目证据链",
+        "deliverables": "把 AI 编程对话和交付记录整理为可核验的九段证据链"
+      },
+      "en": {
+        "menu": "Conversation review",
+        "deliverables": "Turns AI coding conversations and delivery records into a verifiable nine-part evidence chain"
+      }
+    },
+    {
+      "name": "project-guide",
+      "zh": {
+        "menuLabel": "项目导学面经",
+        "prompt": "用 /project-guide 基于项目仓库生成导学和面经。",
+        "opencodeDetail": "基于项目仓库生成导学和面经双文件",
+        "deliverables": "基于项目仓库生成`导学-{简称}.md`、`面经-{简称}.md` 和交接摘要"
+      },
+      "en": {
+        "menu": "Project interview prep",
+        "deliverables": "Generates `导学-{short-name}.md`, `面经-{short-name}.md`, and handoff evidence from a project repository"
+      }
+    },
+    {
+      "name": "great-resume",
+      "zh": {
+        "menuLabel": "简历提升",
+        "prompt": "用 /great-resume 提升我的经历并生成 HR 开场白。",
+        "opencodeDetail": "把真实经历重组为岗位定位、简历要点、HR开场白",
+        "deliverables": "岗位定位、项目改写、成果证据、HR 开场白"
+      },
+      "en": {
+        "menu": "Resume improvement",
+        "deliverables": "Role targeting, project bullet rewrites, evidence of results, HR opener"
+      }
+    },
+    {
+      "name": "make-resume",
+      "zh": {
+        "menuLabel": "简历制作",
+        "prompt": "用 /make-resume 默认基于 ASu 模板制作可编辑 HTML 简历，也可以指定其他模板。",
+        "opencodeDetail": "默认使用 ASu 模板，也可指定其他模板，生成可编辑 HTML 简历并提供 PDF 导出",
+        "deliverables": "默认使用 ASu 模板，也可指定模板；可编辑 HTML 简历和 PDF 导出"
+      },
+      "en": {
+        "menu": "Resume building",
+        "deliverables": "Defaults to the ASu template, supports custom templates, editable HTML resume and PDF export"
+      }
+    },
+    {
+      "name": "job-match",
+      "zh": {
+        "menuLabel": "岗位匹配",
+        "prompt": "用 /job-match 对照目标 JD 与真实经历，判断岗位匹配和证据缺口。",
+        "opencodeDetail": "对照 JD 与真实经历生成证据矩阵和投递建议",
+        "deliverables": "对照 JD 与真实经历，输出证据矩阵、硬性门槛和投递建议"
+      },
+      "en": {
+        "menu": "Job matching",
+        "deliverables": "Compares a JD with verified experience and returns an evidence matrix, hard constraints, and an application recommendation"
+      }
+    },
+    {
+      "name": "job-apply",
+      "zh": {
+        "menuLabel": "简历投递填写",
+        "prompt": "用 /job-apply 通过已连接的浏览器填写求职申请，并在提交前核对。",
+        "opencodeDetail": "通过已连接的浏览器填写申请并在提交前核对",
+        "deliverables": "连接浏览器自动填写求职申请，核对后停在提交前"
+      },
+      "en": {
+        "menu": "Job-application autofill",
+        "deliverables": "Connects to a browser, fills an application, and stops for review before submission"
+      },
+      "excludeFrom": {
+        "workbuddy": "依赖仓库根目录 scripts/ 下的 Kimi WebBridge 桥接脚本与浏览器扩展，纯技能目录桥接无法提供可执行环境"
+      }
+    },
+    {
+      "name": "interview",
+      "zh": {
+        "menuLabel": "面试准备",
+        "prompt": "用 /interview 根据简历预测面试问题并通过连续追问检查掌握程度。",
+        "opencodeDetail": "简历驱动的面试问题预测与连续追问",
+        "deliverables": "面试预测、契约化追问、证据复盘和弱项复练"
+      },
+      "en": {
+        "menu": "Interview preparation",
+        "deliverables": "Interview prediction, contract-driven drilling, evidence review, and targeted retry"
+      }
+    },
+    {
+      "name": "offer",
+      "zh": {
+        "menuLabel": "校招进度管理",
+        "prompt": "用 /offer 记录我的秋招投递和进度。",
+        "opencodeDetail": "记录投递、面试、offer 状态",
+        "deliverables": "投递、测评、面试、Offer、拒信和招聘邮件跟踪"
+      },
+      "en": {
+        "menu": "Campus recruitment tracking",
+        "deliverables": "Tracks applications, assessments, interviews, offers, rejections, and recruiting emails"
+      }
+    }
+  ],
+  "snippets": {
+    "opencodeInstructionsZh": [
+      "1. 克隆仓库到本地",
+      "2. 将 skills/ 目录下所有文件夹复制到 OpenCode 的 skills 目录（通常为 E:\\Cache\\skills\\ 或 ~/.config/opencode/skills/）",
+      "3. 重启 OpenCode 或执行 /reload-plugins",
+      "4. 使用 /project-guide、/great-resume、/make-resume、/job-apply、/interview 等触发词调用"
+    ],
+    "opencodeInstructionsEn": [
+      "1. Clone the repository locally",
+      "2. Copy all folders under skills/ to OpenCode skills directory (usually E:\\Cache\\skills\\ or ~/.config/opencode/skills/)",
+      "3. Restart OpenCode or execute /reload-plugins",
+      "4. Trigger with /project-guide, /great-resume, /make-resume, /job-apply, /interview etc."
+    ]
+  }
+}

--- a/tests/sync-skill-catalog.test.js
+++ b/tests/sync-skill-catalog.test.js
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const syncScript = join(ROOT, 'scripts', 'sync-skill-catalog.mjs');
+
+function loadRegistry() {
+  return JSON.parse(readFileSync(join(ROOT, 'skills.registry.json'), 'utf8'));
+}
+
+test('registry entries are unique and match skills/ directories one-to-one', () => {
+  const reg = loadRegistry();
+  const names = reg.entries.map((e) => e.name);
+  assert.equal(new Set(names).size, names.length, 'duplicate entry names in registry');
+  const dirs = readdirSync(join(ROOT, 'skills'), { withFileTypes: true })
+    .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+    .map((d) => d.name)
+    .sort();
+  assert.deepEqual([...names].sort(), dirs, 'skills/ dirs must equal registry entries');
+  for (const e of reg.entries) {
+    assert.ok(e.zh && e.en, 'entry ' + e.name + ' needs zh/en metadata');
+    assert.ok(e.zh.menuLabel && e.zh.prompt && e.zh.opencodeDetail && e.zh.deliverables, 'entry ' + e.name + ' incomplete zh fields');
+    assert.ok(e.en.menu && e.en.deliverables, 'entry ' + e.name + ' incomplete en fields');
+    assert.ok(e.zh.prompt.startsWith('用 /' + e.name), 'prompt must start with 用 /name');
+  }
+});
+
+test('sync --check passes: every generated artifact is in sync', () => {
+  const out = execFileSync(process.execPath, [syncScript, '--check'], { cwd: ROOT, encoding: 'utf8' });
+  assert.match(out, /sync OK/);
+});


### PR DESCRIPTION
## 变更说明

PR #119 合并后仓库已有 9 个 SKILL，但各宿主清单仍以硬编码方式各自维护，新增入口时出现多处漂移（如 WorkBuddy 注释写"8 个"实际只列 7 个、Claude marketplace 关键词漏 `job-match`、插件版本号 0.3.0 与 package.json 0.4.0 不一致、Issue 模板"相关技能"只有 6 项等）。

本次改动引入根目录 `skills.registry.json` 作为全部入口清单的单一事实源，新增 `npm run sync:skills` 生成/对账脚本统一产出各宿主插件清单、安装脚本与文档中的目录区块，并在 CI 中以 `--check` 强制校验派生文件与 registry 一致，杜绝入口清单再次漂移。

## 变更类型

- [x] `feat`：新增功能或资源（registry + 同步生成脚本）
- [x] `docs`：修改 README、贡献指南或其他文档
- [x] `test`：新增或修改测试
- [x] `ci`：修改 CI/CD 流程或自动化检查

## 关联问题

Fix #107 

## 实现内容

- 主要改动：
  - 新增 [`skills.registry.json`](skills.registry.json)：9 个入口的 zh/en 元数据（`menuLabel`、`prompt`、`opencodeDetail`、`deliverables`）、keywords 与品牌信息；支持按宿主排除（`excludeFrom.workbuddy` 排除 `job-apply` 并注明原因）。
  - 新增 [`scripts/sync-skill-catalog.mjs`](scripts/sync-skill-catalog.mjs)（`npm run sync:skills`）：
    - 从 registry 重写 Codex / TraeWork / Claude Code / OpenCode 的 `plugin.json` 与 Claude `marketplace.json`（keywords、入口、版本号自 `package.json` 传播）；
    - 重写 OpenCode 安装脚本的 `SKILL_NAMES`/触发词、WorkBuddy `install.sh`/`install.ps1`/`install.md` 桥接清单、两份 Issue 模板的"相关技能"选项、README/README_en 的入口总览与目录树（marker 区间内生成）；
    - 同步 `package.json` keywords；
    - `--check` 对账模式：registry 与 `skills/` 目录一一对应、所有派生文件与 registry 一致，不一致时退出码 1。
  - CI（[`.github/workflows/validate-skills.yml`](.github/workflows/validate-skills.yml)）：pr/push 路径过滤加入 `skills.registry.json`，新增 `node scripts/sync-skill-catalog.mjs --check` 步骤。
  - [`scripts/validate_skills.py`](scripts/validate_skills.py) 新增 `check_registry`：入口名唯一、必备字段齐全、与 `skills/` 目录一一对应。
  - 顺带修复已漂移内容：WorkBuddy 桥接清单补全为 8 个（缺 `job-apply`/`job-match`）、Claude marketplace 关键词补 `job-match`、OpenCode 安装指南补 `job-match` 触发词行、Issue 模板选项 6→9、中文标签归一（`面试准备`、`校招进度管理`）、README 目录树修正。
- 改动原因：9 个入口后硬编码清单已实际漂移，需要单一事实源 + 自动生成 + CI 对账，降低后续新增入口的遗漏风险。
- 影响范围：全部宿主插件清单、安装脚本、README/贡献指南、Issue 模板、`package.json`、校验脚本与 CI；`skills/**` 下 SKILL 运行期内容与行为不变。新增/重命名入口的流程收敛为：更新 `skills.registry.json` → `npm run sync:skills` → CI 把关。

## 检查清单

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息（本分支含 `feat:`、`ci:` 两个提交）
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件（`__pycache__` 已清理，工作区干净）
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查（见"验证结果"）
- [ ] 若修改 HTML，已在浏览器中预览并检查编辑、保存、分页和导出效果（不适用：本次未修改 HTML 模板）
- [ ] 若修改简历模板，已确认只修改用户专属副本，没有直接改动只读母版（不适用：本次未修改简历模板）
- [ ] 若新增图片或 Logo，已按仓库资源规范处理（不适用：本次未新增图片或 Logo）
- [x] 若提交历史中存在 `merge/revert` 操作，确认修改内容中无未处理的冲突标记（已扫描，冲突标记 0 处）
- [x] 若与最新主分支存在合并冲突，已保留双方有效内容并解决所有冲突（基于最新 `origin/main` `92c821f` 检出，无冲突）

## 验证结果

```text
node scripts/sync-skill-catalog.mjs --check
=> skill catalog sync OK (9 entries, nothing to change)

python3 scripts/validate_skills.py
=> skills validation: 134/134 checks passed

python3 -m unittest discover -s tests
=> Ran 47 tests ... OK

node --test
=> tests 5, pass 5, fail 0

git diff --check
=> 无输出（通过）

git status --short
=> 干净（无未提交改动）
```

HTML/简历模板/图片项均不适用（本次无相关文件改动），已在清单中标注。

## 额外说明

- `job-apply` 有意不纳入 WorkBuddy 纯目录桥接：它依赖仓库根 `scripts/` 下的 Kimi WebBridge 桥接脚本与浏览器扩展，排除原因已写入 registry 与 `install.md`；若后续改为可桥接，移除 `excludeFrom.workbuddy` 后重新运行 `npm run sync:skills` 即可。
- 插件版本号以 `package.json` 为唯一来源，升版本后运行一次 `npm run sync:skills` 即可传播到各清单。
- 自动维护边界：marker 区间与整文件目标由脚本接管；README/各 SKILL.md 中逐条列举入口的散文段落仍需手工同步。另外 `docs/` 官网页面目前仍手动枚举入口，尚未接入 registry，建议作为后续独立改动跟进。