### PR TITLE
fix: 目录同步脚本输出统一为 LF 行尾

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# 由 scripts/sync-skill-catalog.mjs 生成/维护的文本文件：统一 LF 存储与检出
+# （避免 Windows core.autocrlf 在检出时改写为 CRLF，造成同步/对账噪音）
+.codex-plugin/*.json text eol=lf
+.trae-plugin/*.json text eol=lf
+.claude-plugin/*.json text eol=lf
+.opencode-plugin/*.json text eol=lf
+package.json text eol=lf
+.opencode-plugin/install-opencode.py text eol=lf
+.workbuddy-plugin/*.sh text eol=lf
+.workbuddy-plugin/*.ps1 text eol=lf
+.workbuddy-plugin/*.md text eol=lf
+.github/ISSUE_TEMPLATE/*.yml text eol=lf
+README.md text eol=lf
+README_en.md text eol=lf

--- a/scripts/sync-skill-catalog.mjs
+++ b/scripts/sync-skill-catalog.mjs
@@ -16,6 +16,7 @@
  *   - .workbuddy-plugin/install.md 的目录清单区
  *   - README.md / README_en.md 的入口总览区
  *   - .github/ISSUE_TEMPLATE/*.yml 的“相关技能”选项
+ *   - 输出统一以 LF 为行尾；--check 不受工作区 CRLF 检出影响
  */
 import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -46,8 +47,12 @@ function withRegion(text, id, kind, body) {
   const tail = text.slice(lineEnd + 1);
   return text.slice(0, lineStart) + block + NL + tail;
 }
-function read(rel) { return readFileSync(join(ROOT, rel), 'utf8'); }
-function write(rel, text) { writeFileSync(join(ROOT, rel), text.endsWith(NL) ? text : text + NL); }
+function read(rel) { return readFileSync(join(ROOT, rel), 'utf8').replace(/\r\n?/g, NL); }
+function readRaw(rel) { return readFileSync(join(ROOT, rel), 'utf8'); }
+function write(rel, text) {
+  const lf = text.replace(/\r\n?/g, NL);
+  writeFileSync(join(ROOT, rel), lf.endsWith(NL) ? lf : lf + NL);
+}
 
 // ------------------------------------------------ inputs
 const registry = JSON.parse(read('skills.registry.json'));
@@ -274,20 +279,29 @@ for (const t of regionTargets) {
   stage(t.rel, text, withRegion(text, t.id, t.kind, t.body));
 }
 
-if (changes.length) {
-  if (CHECK) {
+if (CHECK) {
+  if (changes.length) {
     console.error('skill catalog drift detected:');
     for (const c of changes) console.error('  - ' + c);
     console.error('请运行 node scripts/sync-skill-catalog.mjs 后重新提交。');
     process.exit(1);
   }
-  for (const [rel, next] of fileTargets) write(rel, next);
+  console.log('skill catalog sync OK (' + entries.length + ' entries, nothing to change)');
+} else {
+  const synced = [];
+  for (const [rel, next] of fileTargets) {
+    if (readRaw(rel) !== next) { write(rel, next); synced.push(rel); }
+  }
   for (const t of regionTargets) {
     const text = read(t.rel);
-    write(t.rel, withRegion(text, t.id, t.kind, t.body));
+    const next = withRegion(text, t.id, t.kind, t.body);
+    if (readRaw(t.rel) !== next) { write(t.rel, next); synced.push(t.rel); }
   }
-  console.log('synced ' + changes.length + ' target(s):');
-  for (const c of changes) console.log('  - ' + c);
-} else {
-  console.log('skill catalog sync OK (' + entries.length + ' entries, nothing to change)');
+  const uniqSynced = [...new Set(synced)];
+  if (uniqSynced.length) {
+    console.log('synced ' + uniqSynced.length + ' file(s):');
+    for (const c of uniqSynced) console.log('  - ' + c + (changes.includes(c) ? '' : '（行尾统一为 LF）'));
+  } else {
+    console.log('skill catalog sync OK (' + entries.length + ' entries, nothing to change)');
+  }
 }

--- a/tests/sync-skill-catalog.test.js
+++ b/tests/sync-skill-catalog.test.js
@@ -33,3 +33,26 @@ test('sync --check passes: every generated artifact is in sync', () => {
   const out = execFileSync(process.execPath, [syncScript, '--check'], { cwd: ROOT, encoding: 'utf8' });
   assert.match(out, /sync OK/);
 });
+
+test('generated catalog files use LF line endings', () => {
+  const rels = [
+    '.codex-plugin/plugin.json',
+    '.trae-plugin/plugin.json',
+    '.claude-plugin/plugin.json',
+    '.claude-plugin/marketplace.json',
+    '.opencode-plugin/plugin.json',
+    'package.json',
+    '.opencode-plugin/install-opencode.py',
+    '.workbuddy-plugin/install.sh',
+    '.workbuddy-plugin/install.ps1',
+    '.workbuddy-plugin/install.md',
+    'README.md',
+    'README_en.md',
+    '.github/ISSUE_TEMPLATE/bug_report.yml',
+    '.github/ISSUE_TEMPLATE/feature_request.yml',
+  ];
+  for (const rel of rels) {
+    const text = readFileSync(join(ROOT, rel), 'utf8');
+    assert.ok(!text.includes('\r'), rel + ' must use LF line endings');
+  }
+});


### PR DESCRIPTION
## 变更说明

修复 PR #128 中的同步脚本行尾问题

## 变更类型

- [x] `fix`：修复问题

## 关联问题

PR #128 

## 检查清单

提交 PR 前请完成以下检查。无法完成的项目必须在“验证结果”中说明原因和替代方案。

- [x] 已阅读根目录 [`AGENTS.md`](../AGENTS.md)
- [x] 已阅读 [`.github/CONTRIBUTING.md`](CONTRIBUTING.md)
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查
- [x] 若修改 HTML，已在浏览器中预览并检查编辑、保存、分页和导出效果
- [x] 若新增图片或 Logo，已按仓库资源规范处理，没有使用低清截图或自行绘制品牌 Logo
- [x] 若提交历史中存在 `merge/revert` 操作，确认修改内容中无未处理的冲突标记（`<<<<<<<`、`=======`、`>>>>>>>`）
- [x] 若与最新主分支存在合并冲突，已保留双方有效内容并解决所有冲突，随后重新执行本清单中的检查

## 验证结果

npm run sync:skills

```text
在 pwsh 和 bash 环境下输出文件均以 LF 结尾

> asu-skills@0.4.0 sync:skills
> node scripts/sync-skill-catalog.mjs

skill catalog sync OK (9 entries, nothing to change)
```

## 额外说明

<!-- 可补充兼容性、已知限制、截图或后续计划。没有请填写“无”。 -->
