### PR TITLE
fix(opencode): 安装简历与求职进度共享资源

### DIFF
--- a/.opencode-plugin/install-opencode.py
+++ b/.opencode-plugin/install-opencode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 ASu-skills OpenCode 安装脚本
-自动将 skills/ 目录复制到 OpenCode 的 skills 目录
+自动安装 skills/ 以及 make-resume、offer 依赖的共享资源
 """
 import argparse
 import os
@@ -74,7 +74,7 @@ def find_opencode_skills_dir():
 
 
 def install_skills(skills_dir, source_dir):
-    """将 skills 复制到目标目录"""
+    """将 skills 与共享资源复制到 OpenCode 配置目录。"""
     source = Path(source_dir)
     target = Path(skills_dir)
 
@@ -109,6 +109,25 @@ def install_skills(skills_dir, source_dir):
             print(f"[ERROR] 安装 {skill_name} 失败: {exc}")
             return False
         print(f"[OK] {skill_name}")
+
+    resource_root = target.parent
+    for resource_name in ("assets", "references"):
+        src = source.parent / resource_name
+        dst = resource_root / resource_name / "asu"
+
+        if not src.is_dir():
+            print(f"[ERROR] 共享资源目录不存在: {src}")
+            return False
+
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if dst.exists():
+                shutil.rmtree(dst)
+            shutil.copytree(src, dst)
+        except OSError as exc:
+            print(f"[ERROR] 安装共享资源 {resource_name} 失败: {exc}")
+            return False
+        print(f"[OK] {resource_name}/asu")
 
     print()
     print("[OK] 安装完成！请重启 OpenCode 或执行 /reload-plugins")

--- a/.opencode-plugin/installation-guide.md
+++ b/.opencode-plugin/installation-guide.md
@@ -23,6 +23,8 @@ python .opencode-plugin/install-opencode.py --target /custom/opencode/skills
 
 `--target` 优先于自动查找；指定目录不存在时，安装脚本会自动创建。路径中包含空格时请使用引号。
 
+安装脚本除复制 `skills/` 外，还会把共享 `assets/` 与 `references/` 安装到 skills 目录的上一级，分别保存为 `assets/asu/` 与 `references/asu/`。这样 `/make-resume` 和 `/offer` 能在 OpenCode 中继续定位模板与参考资料。
+
 ## 方法 2：手动安装
 
 先 clone 并进入仓库：
@@ -38,6 +40,8 @@ cd ASu-skills
 
 ```bat
 xcopy /E /I "skills\*" "%USERPROFILE%\.config\opencode\skills"
+xcopy /E /I "assets\*" "%USERPROFILE%\.config\opencode\assets\asu"
+xcopy /E /I "references\*" "%USERPROFILE%\.config\opencode\references\asu"
 ```
 
 `/I` 会将不存在的目标视为目录并创建；路径引号用于兼容包含空格的用户名。
@@ -45,8 +49,10 @@ xcopy /E /I "skills\*" "%USERPROFILE%\.config\opencode\skills"
 **macOS / Linux（Bash / Zsh）：**
 
 ```bash
-mkdir -p "$HOME/.config/opencode/skills"
+mkdir -p "$HOME/.config/opencode/skills" "$HOME/.config/opencode/assets/asu" "$HOME/.config/opencode/references/asu"
 cp -r skills/* "$HOME/.config/opencode/skills/"
+cp -r assets/* "$HOME/.config/opencode/assets/asu/"
+cp -r references/* "$HOME/.config/opencode/references/asu/"
 ```
 
 复制完成后重启 OpenCode。

--- a/tests/test_opencode_installer.py
+++ b/tests/test_opencode_installer.py
@@ -47,6 +47,12 @@ class OpenCodeInstallerTests(unittest.TestCase):
             self.assertEqual(set(installer.SKILL_NAMES), expected_skills)
             for skill_name in expected_skills:
                 self.assertTrue((target / skill_name / "SKILL.md").is_file())
+            self.assertTrue(
+                (target.parent / "assets" / "asu" / "asu-resume-template.html").is_file()
+            )
+            self.assertTrue(
+                (target.parent / "references" / "asu" / "email-monitoring.md").is_file()
+            )
 
     def test_without_target_uses_auto_discovery(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## 变更说明

修复 OpenCode 安装器只复制 skills、未安装共享资源的问题。安装完成后，/make-resume 可定位 ASu 简历模板，/offer 可定位邮件监控参考资料。

## 变更类型

- [ ] feat：新增功能或资源
- [x] fix：修复问题
- [x] docs：修改 README、贡献指南或其他文档
- [ ] refactor：重构目录或实现，不改变功能
- [ ] chore：构建、依赖或维护性修改
- [x] test：新增或修改测试
- [ ] ci：修改 CI/CD 流程或自动化检查

## 关联问题

Refs #115

## 实现内容

- 主要改动：OpenCode 安装器将共享 assets/ 与 references/ 分别复制到配置目录下的 assets/asu/ 与 references/asu/。
- 改动原因：现有脚本虽然成功安装 9 个 skills，但 make-resume 与 offer 所需模板和参考资料在独立复制布局中缺失。
- 影响范围：仅影响 .opencode-plugin 安装流程、对应安装文档和安装器测试。

## 检查清单

- [x] 已阅读根目录 AGENTS.md
- [x] 已阅读 .github/CONTRIBUTING.md
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已检查 README、Markdown 和图片资源使用正确的仓库内相对路径
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查
- [x] 本次未修改 HTML，无需浏览器预览
- [x] 本次未新增图片或 Logo
- [x] 已检查无冲突标记
- [x] 当前分支基于最新 origin/main，无合并冲突

## 验证结果

- python -m unittest tests.test_opencode_installer -v：5/5 通过
- python -m unittest discover -s tests -v：48/48 通过
- npm test：6/6 通过
- git diff --cached --check：通过
- GitHub 发布前脱敏扫描：blockers=0，advisories=0，publish_gate=passed

## 额外说明

安装器只覆盖 ASu 自己管理的 assets/asu 与 references/asu 子目录，不删除同级其他项目资源。