### PR TITLE
docs: list all skill triggers in OpenCode guide

### DIFF
--- a/.opencode-plugin/plugin.json
+++ b/.opencode-plugin/plugin.json
@@ -78,13 +78,13 @@
         "1. 克隆仓库到本地",
         "2. 将 skills/ 目录下所有文件夹复制到 OpenCode 的 skills 目录（通常为 E:\\Cache\\skills\\ 或 ~/.config/opencode/skills/）",
         "3. 重启 OpenCode 或执行 /reload-plugins",
-        "4. 使用 /project-guide、/great-resume、/make-resume、/job-apply、/interview 等触发词调用"
+        "4. 使用 /contributor、/evidence-recap、/project-guide、/great-resume、/make-resume、/job-match、/job-apply、/interview、/offer 等触发词调用"
       ],
       "en": [
         "1. Clone the repository locally",
         "2. Copy all folders under skills/ to OpenCode skills directory (usually E:\\Cache\\skills\\ or ~/.config/opencode/skills/)",
         "3. Restart OpenCode or execute /reload-plugins",
-        "4. Trigger with /project-guide, /great-resume, /make-resume, /job-apply, /interview etc."
+        "4. Trigger with /contributor, /evidence-recap, /project-guide, /great-resume, /make-resume, /job-match, /job-apply, /interview, /offer etc."
       ]
     }
   }

--- a/skills.registry.json
+++ b/skills.registry.json
@@ -153,13 +153,13 @@
       "1. 克隆仓库到本地",
       "2. 将 skills/ 目录下所有文件夹复制到 OpenCode 的 skills 目录（通常为 E:\\Cache\\skills\\ 或 ~/.config/opencode/skills/）",
       "3. 重启 OpenCode 或执行 /reload-plugins",
-      "4. 使用 /project-guide、/great-resume、/make-resume、/job-apply、/interview 等触发词调用"
+      "4. 使用 /contributor、/evidence-recap、/project-guide、/great-resume、/make-resume、/job-match、/job-apply、/interview、/offer 等触发词调用"
     ],
     "opencodeInstructionsEn": [
       "1. Clone the repository locally",
       "2. Copy all folders under skills/ to OpenCode skills directory (usually E:\\Cache\\skills\\ or ~/.config/opencode/skills/)",
       "3. Restart OpenCode or execute /reload-plugins",
-      "4. Trigger with /project-guide, /great-resume, /make-resume, /job-apply, /interview etc."
+      "4. Trigger with /contributor, /evidence-recap, /project-guide, /great-resume, /make-resume, /job-match, /job-apply, /interview, /offer etc."
     ]
   }
 }


### PR DESCRIPTION
## 变更说明

补全 OpenCode 安装说明中的 skill 触发词列表，使文档与仓库当前的 9 个 skill 保持一致。

## 变更类型

- [ ] `feat`：新增功能或资源
- [ ] `fix`：修复问题
- [x] `docs`：修改 README、贡献指南或其他文档
- [ ] `refactor`：重构目录或实现，不改变功能
- [ ] `chore`：构建、依赖或维护性修改
- [ ] `test`：新增或修改测试
- [ ] `ci`：修改 CI/CD 流程或自动化检查

## 关联问题

无。

## 实现内容

- 主要改动：在 `skills.registry.json` 中补充 `contributor`、`evidence-recap`、`job-match`、`offer` 四个触发词。
- 改动原因：原说明只列出 5 个 skill，无法完整反映仓库提供的 9 个 skill。
- 影响范围：同步更新 `.opencode-plugin/plugin.json`，仅影响安装说明文案。

## 检查清单

- [x] 已阅读根目录 `AGENTS.md`
- [x] 已阅读 `.github/CONTRIBUTING.md`
- [x] 已按中文 Conventional Commits 规范编写提交信息
- [x] 已检查没有提交密钥、个人隐私、临时文件或无关文件
- [x] 已完成与本次改动相关的 JSON、技能校验或其他自动化检查
- [x] 已检查没有未处理的冲突标记

## 验证结果

```text
node scripts/sync-skill-catalog.mjs --check 通过
node --test：6/6 通过
git diff --check 通过
python skill 校验未执行：本机 Python 启动器异常
```

## 额外说明

无。