### PR TITLE
fix: 补全 macOS 浏览器默认路径

### DIFF
--- a/scripts/export-resume-pdf.mjs
+++ b/scripts/export-resume-pdf.mjs
@@ -46,6 +46,10 @@ const BROWSERS = [
   '/usr/bin/microsoft-edge',
   '/usr/bin/google-chrome',
   '/usr/bin/chromium',
+  // macOS
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+  '/Applications/Chromium.app/Contents/MacOS/Chromium',
 ].filter(Boolean);
 
 const browserPath = BROWSERS.find((p) => existsSync(p));


### PR DESCRIPTION
## What

`scripts/export-resume-pdf.mjs` 的 `BROWSERS` 列表补上 macOS 标准浏览器安装路径：

- `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`
- `/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge`
- `/Applications/Chromium.app/Contents/MacOS/Chromium`

## Why

macOS 上浏览器默认安装在 `/Applications/<浏览器>.app/Contents/MacOS/`，而原列表只有 Windows（`C:\Program Files\...`）和 Linux（`/usr/bin/...`）路径。结果 macOS 用户即使装了 Chrome/Edge，脚本也会报「未找到 Edge/Chrome」，只能手动传 `--browser` 或设置 `EDGE_PATH`/`CHROME_PATH`。

我本人在 macOS 上导出简历 PDF 时就遇到了这个问题：机器上明明装了 Chrome 和 Edge，脚本却提示找不到浏览器，最后只能手动加 `--browser "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"` 才能跑通。补上默认路径后即可开箱即用。

## How verified

- `node --check scripts/export-resume-pdf.mjs` 通过；
- 在 macOS（已安装 Chrome/Edge）上不传 `--browser` 直接运行，成功自动定位 Chrome 并导出 PDF（退出码 0）。