### PR TITLE
test: 修复 Python 测试发现路径

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -54,7 +54,7 @@ jobs:
         run: python3 scripts/validate_skills.py
 
       - name: Run unit tests
-        run: python3 -m unittest discover -s tests -v
+        run: python3 -m unittest discover -s tests -t . -v
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "sync:skills": "node scripts/sync-skill-catalog.mjs",
     "sync:skills:check": "node scripts/sync-skill-catalog.mjs --check",
     "validate:skills": "python3 scripts/validate_skills.py",
-    "test:python": "python3 -m unittest discover -s tests -v",
+    "test:python": "python3 -m unittest discover -s tests -t . -v",
     "test": "node --test"
   },
   "main": "./lib/index.js",

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable Python helpers and command-line scripts for ASu-skills."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Python test package for unittest discovery."""


### PR DESCRIPTION
## 变更说明

修复 Python unittest 在仓库根目录执行时无法导入 `scripts.*` 模块的问题。

## 变更类型

- [x] `test`：新增或修改测试
- [x] `ci`：修改 CI/CD 流程或自动化检查

## 关联问题

无。

## 实现内容

- 为 `scripts/` 和 `tests/` 增加 Python 包入口文件；
- 将本地测试脚本和 GitHub Actions 的 unittest discovery 命令统一为显式指定仓库顶层目录；
- 保持现有测试逻辑和生产代码不变。

## 验证结果

- `python3 -m unittest discover -s tests -t . -v`：48 个测试全部通过；
- `npm run test:python`：通过；
- `python3 scripts/validate_skills.py`：通过；
- `npm run sync:skills:check`：通过；
- `node --test`：7 个测试全部通过；
- `git diff --check`：通过；
- 未发现冲突标记。

## 影响范围

仅影响 Python 测试发现入口和 CI 测试命令，不改变运行时业务逻辑。