### PR TITLE
fix: 补齐 OpenCode 安装后的简历构建脚本与资源定位

### DIFF
--- a/.opencode-plugin/install-opencode.py
+++ b/.opencode-plugin/install-opencode.py
@@ -129,6 +129,17 @@ def install_skills(skills_dir, source_dir):
             return False
         print(f"[OK] {resource_name}/asu")
 
+    # Keep builders beside the installed resources so they work without the clone.
+    scripts_target = resource_root / "assets" / "asu" / "scripts"
+    try:
+        scripts_target.mkdir(parents=True, exist_ok=True)
+        for name in ("build-asu-resume.mjs", "inline-template.mjs", "export-resume-pdf.mjs"):
+            shutil.copy2(source.parent / "scripts" / name, scripts_target / name)
+    except OSError as exc:
+        print(f"[ERROR] 安装简历脚本失败: {exc}")
+        return False
+    print("[OK] 简历构建与导出脚本")
+
     print()
     print("[OK] 安装完成！请重启 OpenCode 或执行 /reload-plugins")
     print("   使用触发词：" + TRIGGER_WORDS)

--- a/.opencode-plugin/installation-guide.md
+++ b/.opencode-plugin/installation-guide.md
@@ -23,7 +23,7 @@ python .opencode-plugin/install-opencode.py --target /custom/opencode/skills
 
 `--target` 优先于自动查找；指定目录不存在时，安装脚本会自动创建。路径中包含空格时请使用引号。
 
-安装脚本除复制 `skills/` 外，还会把共享 `assets/` 与 `references/` 安装到 skills 目录的上一级，分别保存为 `assets/asu/` 与 `references/asu/`。这样 `/make-resume` 和 `/offer` 能在 OpenCode 中继续定位模板与参考资料。
+安装脚本除复制 `skills/` 外，还会把共享 `assets/` 与 `references/` 安装到 skills 目录的上一级，分别保存为 `assets/asu/` 与 `references/asu/`。简历构建与 PDF 导出脚本另存到 `assets/asu/scripts/`；运行需要 Node.js（版本要求见根目录 `package.json`），PDF 自动导出还需要本机 Chrome/Edge。这样 `/make-resume` 和 `/offer` 能在 OpenCode 中继续定位模板与参考资料。
 
 ## 方法 2：手动安装
 
@@ -41,6 +41,8 @@ cd ASu-skills
 ```bat
 xcopy /E /I "skills\*" "%USERPROFILE%\.config\opencode\skills"
 xcopy /E /I "assets\*" "%USERPROFILE%\.config\opencode\assets\asu"
+mkdir "%USERPROFILE%\.config\opencode\assets\asu\scripts"
+for %f in (build-asu-resume.mjs inline-template.mjs export-resume-pdf.mjs) do copy "scripts\%f" "%USERPROFILE%\.config\opencode\assets\asu\scripts\"
 xcopy /E /I "references\*" "%USERPROFILE%\.config\opencode\references\asu"
 ```
 
@@ -52,10 +54,20 @@ xcopy /E /I "references\*" "%USERPROFILE%\.config\opencode\references\asu"
 mkdir -p "$HOME/.config/opencode/skills" "$HOME/.config/opencode/assets/asu" "$HOME/.config/opencode/references/asu"
 cp -r skills/* "$HOME/.config/opencode/skills/"
 cp -r assets/* "$HOME/.config/opencode/assets/asu/"
+mkdir -p "$HOME/.config/opencode/assets/asu/scripts"
+cp scripts/build-asu-resume.mjs scripts/inline-template.mjs scripts/export-resume-pdf.mjs "$HOME/.config/opencode/assets/asu/scripts/"
 cp -r references/* "$HOME/.config/opencode/references/asu/"
 ```
 
-复制完成后重启 OpenCode。
+复制完成后重启 OpenCode。Windows 命令写入 `.bat` 文件时，将 `%f` 改为 `%%f`。
+
+可从任意工作目录验证默认简历构建（macOS / Linux 示例；自定义安装时替换路径）：
+
+```bash
+node "$HOME/.config/opencode/assets/asu/scripts/build-asu-resume.mjs" "$HOME/.config/opencode/assets/asu/asu-resume/template.html" "./resume-check.html"
+```
+
+打开生成的 `resume-check.html`，应能看到编辑和保存工具栏。该命令不会修改模板母版；正式制作时先复制内容壳，在用户副本上修改。
 
 ## 方法 3：通过 OpenCode 插件管理器（如果支持）
 

--- a/scripts/build-asu-resume.mjs
+++ b/scripts/build-asu-resume.mjs
@@ -5,14 +5,17 @@ import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const sourceDir = path.join(repoRoot, 'assets', 'asu-resume');
-const frameDir = path.join(repoRoot, 'assets', 'frame', 'asu');
+// OpenCode installs these scripts inside assets/asu/scripts.
+const assetsRoot = fs.existsSync(path.join(repoRoot, 'frame', 'asu', 'base.css'))
+  ? repoRoot : path.join(repoRoot, 'assets');
+const sourceDir = path.join(assetsRoot, 'asu-resume');
+const frameDir = path.join(assetsRoot, 'frame', 'asu');
 const sharedDir = path.dirname(frameDir);
 const [input, destination] = process.argv.slice(2);
 const custom = input && input !== '--check';
 if (custom && !destination) throw new Error('用法：node scripts/build-asu-resume.mjs <用户内容壳> <输出 HTML>');
-const outputPath = custom ? path.resolve(destination) : path.join(repoRoot, 'assets', 'asu-resume-template.html');
-if (custom && [path.resolve(input), path.join(sourceDir, 'template.html'), path.join(repoRoot, 'assets', 'asu-resume-template.html')].includes(outputPath)) {
+const outputPath = custom ? path.resolve(destination) : path.join(assetsRoot, 'asu-resume-template.html');
+if (custom && [path.resolve(input), path.join(sourceDir, 'template.html'), path.join(assetsRoot, 'asu-resume-template.html')].includes(outputPath)) {
   throw new Error('用户输出不能覆盖内容壳或仓库母版');
 }
 

--- a/scripts/inline-template.mjs
+++ b/scripts/inline-template.mjs
@@ -18,7 +18,11 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-const TEMPLATES_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'assets', 'templates-html');
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+// Support the OpenCode assets/asu/scripts layout as well as the repository.
+const assetsRoot = fs.existsSync(path.join(root, 'frame', 'base.css'))
+  ? root : path.join(root, 'assets');
+const TEMPLATES_DIR = path.join(assetsRoot, 'templates-html');
 const FRAME_LINK = '<link rel="stylesheet" href="../frame/base.css">';
 
 // 壳文件预览专用的 SHELL-ONLY 规则块（frame/base.css 末尾），交付时整块移除。

--- a/skills/make-resume/SKILL.md
+++ b/skills/make-resume/SKILL.md
@@ -25,7 +25,9 @@ description: 中文可编辑简历制作技能：默认基于 ASu 单栏高密�
 
 仓库中的 `assets/asu-resume/template.html` 和 `assets/templates-html/` 为模板壳文件，共享外框位于 `assets/frame/`。Agent 只读取内容壳，在用户目录创建并修改副本。壳文件只有设计稿，交付前必须用 `scripts/` 下的脚本内联共享的 `base.css`、`toolbar.css`、`toolbar.html` 和 `editor.js`，生成自包含 HTML；不能把壳文件直接交给用户。参考截图只用于分析版式，不能整页嵌入最终简历。
 
-如果 skill 被单独复制到其他目录，先从当前 skill 目录向上定位 `assets/`，只有在该目录包含完整模板资源时才使用它。完整资源至少包括 `resume-data-template.json`、`template-overview.jpg`、`fictional-resume-photo.png`、`frame/` 下的 `base.css`、`toolbar.css`、`toolbar.html`、`editor.js`，以及全部 18 个模板壳文件。找不到完整资源时必须明确说明，使用简洁 A4 后备模板，并说明不保证 18 套模板、预览图、示例照片或原模板复刻精度。
+OpenCode 安装布局使用配置目录下的 `assets/asu/` 保存模板资源，简历构建与导出脚本位于该资源目录的 `scripts/` 子目录。此布局下，将下文的仓库资源路径替换为已安装资源的绝对路径，并用 `node "<已安装脚本绝对路径>" "<用户内容壳绝对路径>" "<输出 HTML 绝对路径>"` 构建，无需回到原克隆目录。
+
+如果 skill 被单独复制到其他目录，先从当前 skill 目录向上定位 `assets/asu/` 或 `assets/`，只有在该目录包含完整模板资源时才使用它。完整资源至少包括 `resume-data-template.json`、`template-overview.jpg`、`fictional-resume-photo.png`、`frame/` 下的 `base.css`、`toolbar.css`、`toolbar.html`、`editor.js`，以及全部 18 个模板壳文件。找不到完整资源时必须明确说明，使用简洁 A4 后备模板，并说明不保证 18 套模板、预览图、示例照片或原模板复刻精度。
 
 ## 工作流程
 

--- a/tests/test_opencode_installer.py
+++ b/tests/test_opencode_installer.py
@@ -1,6 +1,8 @@
 import contextlib
 import importlib.util
 import io
+import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -53,6 +55,47 @@ class OpenCodeInstallerTests(unittest.TestCase):
             self.assertTrue(
                 (target.parent / "references" / "asu" / "email-monitoring.md").is_file()
             )
+
+    @unittest.skipUnless(shutil.which("node"), "Node.js is required for resume builds")
+    def test_installed_builders_generate_resumes_from_an_unrelated_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            target = root / "OpenCode config" / "skills"
+            with contextlib.redirect_stdout(io.StringIO()):
+                self.assertEqual(installer.main(["--target", str(target)]), 0)
+            assets = target.parent / "assets" / "asu"
+            user_dir = root / "user resumes"
+            user_dir.mkdir()
+            cases = (
+                ("build-asu-resume.mjs", assets / "asu-resume" / "template.html"),
+                ("inline-template.mjs", next((assets / "templates-html").glob("*.html"))),
+            )
+            for script, template in cases:
+                with self.subTest(script=script):
+                    original = template.read_bytes()
+                    shell = user_dir / "content.html"
+                    shutil.copyfile(template, shell)
+                    output = user_dir / "resume.html"
+                    installed_script = assets / "scripts" / script
+                    self.assertTrue(installed_script.is_file())
+                    result = subprocess.run(
+                        [shutil.which("node"), str(installed_script), str(shell), str(output)],
+                        cwd=user_dir, capture_output=True, text=True,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    html = output.read_text(encoding="utf-8")
+                    self.assertIn('data-action="save"', html)
+                    self.assertIn("<script>", html)
+                    self.assertNotIn('<link rel="stylesheet"', html)
+                    reference = user_dir / "reference.html"
+                    baseline = subprocess.run(
+                        [shutil.which("node"), str(ROOT / "scripts" / script), str(shell), str(reference)],
+                        cwd=user_dir, capture_output=True, text=True,
+                    )
+                    self.assertEqual(baseline.returncode, 0, baseline.stderr)
+                    self.assertEqual(output.read_bytes(), reference.read_bytes())
+                    self.assertEqual(template.read_bytes(), original)
+                    self.assertEqual(shell.read_bytes(), original)
 
     def test_without_target_uses_auto_discovery(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## 变更说明

OpenCode 安装完成后，模板资源位于 `assets/asu/`，但安装器没有复制 `/make-resume` 所需的构建脚本。两个构建脚本也只按仓库目录结构查找资源，导致安装后的模板无法直接按技能说明生成完整 HTML。

本次补齐脚本安装，并让构建器支持安装后的资源布局，用户无需回到原克隆目录即可生成简历。

## 变更类型

- [x] `fix`：修复问题

## 关联问题

无。

## 实现内容

- 将简历构建和 PDF 导出脚本安装到 `assets/asu/scripts/`。
- 两个 HTML 构建器兼容仓库布局与 OpenCode 安装布局。
- 同步自动安装、手动安装和技能中的资源定位说明。
- 新增安装后构建测试，覆盖带空格的路径及从其他工作目录调用脚本。

## 检查清单

- [x] 已阅读根目录 `AGENTS.md` 和 `.github/CONTRIBUTING.md`。
- [ ] 提交信息符合中文 Conventional Commits 规范：现有提交标题冒号后缺少空格，PR 标题已规范化。
- [x] 已检查无密钥、个人隐私、临时文件或无关改动。
- [x] 已检查文档资源路径及相关自动化检查。
- HTML 浏览器预览、图片和 Logo 检查：本次未修改这些文件；构建输出的一致性见下方验证结果。
- 本分支未新增 merge/revert 操作。

## 验证结果

新增测试在修复前因缺少两个构建脚本失败，修复后通过。测试先安装到含空格的临时目录，再从独立用户目录调用已安装的脚本，分别生成默认 ASu 简历和另一套模板。输出与仓库构建结果逐字节一致，输入副本和模板母版均未改变。

- `python3 -m unittest discover -s tests -v`：49 项通过，包含安装后的 Node 构建测试。
- `node --test`：8 项通过。
- `python3 scripts/validate_skills.py`：135/135 项通过。
- `node scripts/sync-skill-catalog.mjs --check`：通过。
- `node scripts/build-asu-resume.mjs --check`：通过。
- `node scripts/inline-template.mjs --all <临时目录>`：通过。
- 两个修改脚本的 `node --check`、`npm pack --dry-run` 和 `git diff --check`：通过。

## 额外说明

验证范围为安装器与 HTML 构建链路。尚未在真实 OpenCode 会话、Windows CMD 手动安装及浏览器 PDF 导出场景中验证，未提供真实 OpenCode 对话案例。
